### PR TITLE
Small enhancement to old api: Updated create_group to return the created group

### DIFF
--- a/vistrails/api/__init__.py
+++ b/vistrails/api/__init__.py
@@ -175,8 +175,9 @@ def add_connection(output_id, output_port_spec, input_id, input_port_spec,
 def create_group(module_ids, connection_ids, controller=None):
     if controller is None:
         controller = get_current_controller()
-    controller.create_group(module_ids, connection_ids)
+    group = controller.create_group(module_ids, connection_ids)
     controller.updatePipelineScene()
+    return group
 
 def get_modules_by_name(name, package=None, namespace=None, controller=None):
     if controller is None:


### PR DESCRIPTION
I realize that you guys have told us to not use the old api and I will modify our current usage of the old api to use the new one eventually. In the mean time, I found this small change to be helpful, especially in the context of wanting to programatically rename the new group to something more interpretable than `Group`
