### PR TITLE
Removes Serializable interface

### DIFF
--- a/vistrails/core/modules/basic_modules.py
+++ b/vistrails/core/modules/basic_modules.py
@@ -158,12 +158,6 @@ class Constant(Module):
     def setValue(self, v):
         self.set_output("value", self.translate_to_python(v))
         self.upToDate = True
-        
-    def serialize(self):
-        return self.outputPorts['value_as_string']
-    
-    def deserialize(self, v):
-        return self.translate_to_python(v)
 
     @staticmethod
     def translate_to_string(v):

--- a/vistrails/core/modules/vistrails_module.py
+++ b/vistrails/core/modules/vistrails_module.py
@@ -185,31 +185,9 @@ class DummyModuleLogging(object):
 _dummy_logging = DummyModuleLogging()
 
 ################################################################################
-# Serializable
-
-class Serializable(object):
-    """
-    Serializable is a mixin class used to define methods to serialize and
-    deserialize modules.
-
-    """
-
-    def serialize(self):
-        """
-        Method used to serialize a module.
-        """
-        raise NotImplementedError('The serialize method is not defined for this module.')
-
-    def deserialize(self):
-        """
-        Method used to deserialize a module.
-        """
-        raise NotImplementedError('The deserialize method is not defined for this module.')
-
-################################################################################
 # Module
 
-class Module(Serializable):
+class Module(object):
     """Module is the base module from which all module functionality
     is derived from in VisTrails. It defines a set of basic interfaces to
     deal with data input/output (through ports, as will be explained


### PR DESCRIPTION
Docstring says "mixin" but it really isn't... It is only used by Module, and no Module subclass seems to implement it, either.

Subclasses of Module are marked as "missing implementation of abstract methods" because of it.

![pycharm screenshot](http://i.imgur.com/WbKwQjJ.png)