### PR TITLE
Fix none comparisons

### DIFF
--- a/vistrails/core/analogy/eigen.py
+++ b/vistrails/core/analogy/eigen.py
@@ -260,7 +260,7 @@ class EigenBase(object):
         (c,) = v.shape
         print "[ ",
         for j in xrange(c):
-            if left_digits != None:
+            if left_digits is not None:
                 d = left_digits[0,j]
             else:
                 d = 0

--- a/vistrails/core/data_structures/graph.py
+++ b/vistrails/core/data_structures/graph.py
@@ -311,7 +311,7 @@ class Graph(object):
         new_id    -- 'immutable' edge id (default None)
         """
         
-        if old_id == None:
+        if old_id is None:
             efroom = self.adjacency_list[old_froom]
             forward_idx = None
             for i, edge in enumerate(efroom):
@@ -983,7 +983,7 @@ class TestGraph(unittest.TestCase):
         g = Graph()
         g.add_vertex(0)
         g.add_vertex(1)
-        assert g.get_edge(0, 1) == None
+        assert g.get_edge(0, 1) is None
 
     def test_dfs_before(self):
         g = self.make_linear(10)

--- a/vistrails/core/data_structures/point.py
+++ b/vistrails/core/data_structures/point.py
@@ -190,7 +190,7 @@ class TestPoint(unittest.TestCase):
         a = Point(0, 1)
         b = Point(0, 1)
         assert a == b
-        assert a != None
+        assert a is not None
         b = Point(0, 0.1)
         assert a != b
 

--- a/vistrails/core/data_structures/rect.py
+++ b/vistrails/core/data_structures/rect.py
@@ -48,12 +48,12 @@ class Rect(object):
         a copy of the given points. Return a Rect
 
         """        
-        if lower_left == None:
+        if lower_left is None:
             self.lower_left = Point()
         else:
             self.lower_left = copy.copy(lower_left)
 
-        if upper_right == None:
+        if upper_right is None:
             self.upper_right = Point()
         else:
             self.upper_right = copy.copy(upper_right)

--- a/vistrails/core/db/locator.py
+++ b/vistrails/core/db/locator.py
@@ -373,7 +373,7 @@ class DBLocator(_DBLocator, CoreLocator):
         """get_connection_info(id: int) -> dict
         Returns info of ExtConnection """
         conn = self.__list.get_connection(id)
-        if conn != None:
+        if conn is not None:
             succeeded = False
             key = str(conn.id) + "." + conn.name + "." + conn.host
             passwd = DBLocator.keyChain.get_key(key)

--- a/vistrails/core/debug.py
+++ b/vistrails/core/debug.py
@@ -187,7 +187,7 @@ class EmitWarnings(logging.Handler):
     def emit(self, record):
         # Here we basically do the contrary of warnings:formatwarning()
         m = _warningformat.match(record.args[0])
-        if m == None:
+        if m is None:
             self.logger.warning("(File info not available)\n" +
                            record.args[0])
         else:

--- a/vistrails/core/external_connection.py
+++ b/vistrails/core/external_connection.py
@@ -143,7 +143,7 @@ class DBConnection(ExtConnection):
         operator. 
         
         """
-        if other == None:
+        if other is None:
             return False
         if self.type != other.type:
             return False

--- a/vistrails/core/layout/tree_layout.py
+++ b/vistrails/core/layout/tree_layout.py
@@ -88,7 +88,7 @@ class TreeLW(object):
         self.maxLevel = max(self.maxLevel, maxLevel)
 
     def __dfsUpdateLevel(self, node):
-        if node.parent == None:
+        if node.parent is None:
             node.level = 0
         else:
             node.level = node.parent.level + 1
@@ -140,13 +140,13 @@ class KeepBoundingBox(object):
         self.size = 0
 
     def addPoint(self,x,y):
-        if self.minx == None or self.minx > x:
+        if self.minx is None or self.minx > x:
             self.minx = x
-        if self.miny == None or self.miny > y:
+        if self.miny is None or self.miny > y:
             self.miny = y
-        if self.maxx == None or self.maxx < x:
+        if self.maxx is None or self.maxx < x:
             self.maxx = x
-        if self.maxy == None or self.maxy < y:
+        if self.maxy is None or self.maxy < y:
             self.maxy = y
         self.size = self.size + 1
 
@@ -379,11 +379,11 @@ class TreeLayoutLW(object):
                 som += vom.mod
                 sop += vop.mod
 
-            if self.nextRight(vim) is not None and self.nextRight(vop) == None:
+            if self.nextRight(vim) is not None and self.nextRight(vop) is None:
                 vop.thread = self.nextRight(vim)
                 vop.mod += sim - sop
 
-            if self.nextLeft(vip) is not None and self.nextLeft(vom) == None:
+            if self.nextLeft(vip) is not None and self.nextLeft(vom) is None:
                 vom.thread = self.nextLeft(vip)
                 vom.mod += sip - som
                 defaultAncestor = v

--- a/vistrails/core/layout/tree_layout.py
+++ b/vistrails/core/layout/tree_layout.py
@@ -70,7 +70,7 @@ class TreeLW(object):
         self.nodes.append(newNode)
 
         # add
-        if parentNode != None:
+        if parentNode is not None:
             parentNode.addChild(newNode)
 
         # update max level
@@ -78,7 +78,7 @@ class TreeLW(object):
         return newNode
 
     def changeParentOfNodeWithNoParent(self, parentNode, childNode):
-        if childNode.parent != None:
+        if childNode.parent is not None:
             raise ValueError("Node already has a parent")
 
         parentNode.addChild(childNode)
@@ -217,13 +217,13 @@ class NodeLW(object):
             return None
 
     def leftMostSibling(self):
-        if self.parent != None:
+        if self.parent is not None:
             return self.parent.childs[0]
         else:
             return self
 
     def isSiblingOf(self, v):
-        return self.parent == v.parent and self.parent != None
+        return self.parent == v.parent and self.parent is not None
 
 class TreeLayoutLW(object):
 
@@ -304,7 +304,7 @@ class TreeLayoutLW(object):
         if v.isLeaf():
             v.prelim = 0
             w = v.leftSibling()
-            if w != None:
+            if w is not None:
                 v.prelim = w.prelim + self.gap(w,v)
 
         else:
@@ -318,7 +318,7 @@ class TreeLayoutLW(object):
             midpoint = (v.leftChild().prelim + v.rightChild().prelim) / 2.0
 
             w = v.leftSibling()
-            if w != None:
+            if w is not None:
                 v.prelim = w.prelim + self.gap(w,v)
                 v.mod = v.prelim - midpoint
             else:
@@ -344,7 +344,7 @@ class TreeLayoutLW(object):
 
         """
         w = v.leftSibling()
-        if w != None:
+        if w is not None:
             # p stands for + or plus (right subtree)
             # m stands for - or minus (left subtree)
             # i stands for inside
@@ -358,7 +358,7 @@ class TreeLayoutLW(object):
             sop = vop.mod
             sim = vim.mod
             som = vom.mod
-            while self.nextRight(vim) != None and self.nextLeft(vip) != None:
+            while self.nextRight(vim) is not None and self.nextLeft(vip) is not None:
                 
                 vim = self.nextRight(vim)
                 vip = self.nextLeft(vip)
@@ -379,11 +379,11 @@ class TreeLayoutLW(object):
                 som += vom.mod
                 sop += vop.mod
 
-            if self.nextRight(vim) != None and self.nextRight(vop) == None:            
+            if self.nextRight(vim) is not None and self.nextRight(vop) == None:
                 vop.thread = self.nextRight(vim)
                 vop.mod += sim - sop
 
-            if self.nextLeft(vip) != None and self.nextLeft(vom) == None:            
+            if self.nextLeft(vip) is not None and self.nextLeft(vom) == None:
                 vom.thread = self.nextLeft(vip)
                 vom.mod += sip - som
                 defaultAncestor = v

--- a/vistrails/core/layout/version_tree_layout.py
+++ b/vistrails/core/layout/version_tree_layout.py
@@ -148,7 +148,7 @@ class VistrailsTreeLayoutLW(object):
             # print "add arc into tree %d -> %d" % (parentId, childId)
             parent = mapTreeNodes[parentId]
             child = mapTreeNodes[childId]
-#             if child.parent != None:
+#             if child.parent is not None:
 #                 print "child already has a parent!!! %d -> %d" % (parentId, childId)
 #                 raise ValueError("Node already has a parent")
             tree.changeParentOfNodeWithNoParent(parent, child)

--- a/vistrails/core/layout/workflow_layout.py
+++ b/vistrails/core/layout/workflow_layout.py
@@ -470,7 +470,7 @@ class WorkflowLayout(object):
         permutation = []
         while True:
             mod = iterator.next()
-            if mod == None:
+            if mod is None:
                 break
             permutation.append(mod)
         permutation.reverse()

--- a/vistrails/core/mashup/controller.py
+++ b/vistrails/core/mashup/controller.py
@@ -108,7 +108,7 @@ class MashupController(object):
         name = ''
         locator = self.currentMashup.vtid
         if locator is not None:
-            if locator.name == None:
+            if locator.name is None:
                 name = ''
             else:
                 name = os.path.split(locator.name)[1]

--- a/vistrails/core/mashup/controller.py
+++ b/vistrails/core/mashup/controller.py
@@ -107,7 +107,7 @@ class MashupController(object):
     def getVistrailName(self):
         name = ''
         locator = self.currentMashup.vtid
-        if locator != None:
+        if locator is not None:
             if locator.name == None:
                 name = ''
             else:

--- a/vistrails/core/mashup/mashup.py
+++ b/vistrails/core/mashup/mashup.py
@@ -48,13 +48,13 @@ class Mashup(DBMashup):
     def __init__(self, id, name, vtid=None, version=None, alias_list=None, 
                  t='vistrail', has_seq=None, layout='', geometry='', 
                  id_scope=IdScope()):
-        if has_seq == None:
+        if has_seq is None:
             has_seq = 0
             
         DBMashup.__init__(self, id, name, version, alias_list, t, vtid, layout, 
                           geometry, has_seq)
         self.id_scope = id_scope
-        if has_seq == None:
+        if has_seq is None:
             self.has_seq = False
             if isinstance(self.alias_list, list):
                 for v in self.alias_list:

--- a/vistrails/core/modules/paramexplore.py
+++ b/vistrails/core/modules/paramexplore.py
@@ -168,7 +168,7 @@ class UserDefinedFunctionInterpolator(object):
             def evaluate(i):
                 try:
                     v = d['value'](i)
-                    if v == None:
+                    if v is None:
                         return self._ptype.default_value
                     return v
                 except Exception, e:

--- a/vistrails/core/thumbnails.py
+++ b/vistrails/core/thumbnails.py
@@ -192,7 +192,7 @@ class ThumbnailCache(object):
         if len(thumbnail_fnames) > 0:
             image = self._merge_thumbnails(thumbnail_fnames)
         fname = None
-        if image != None and image.width() > 0 and image.height() > 0:
+        if image is not None and image.width() > 0 and image.height() > 0:
             fname = "%s.png" % str(uuid.uuid1())
             abs_fname = self._save_thumbnail(image, fname) 
             statinfo = os.stat(abs_fname)

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -2372,7 +2372,7 @@ class VistrailController(object):
                                           descriptor_tuple[1],
                                           descriptor_tuple[4],
                                           [v for k, v in lookup.iteritems()
-                                           if k[1] != None])
+                                           if k[1] is not None])
                 descriptor_tuple = (new_desc.package, new_desc.name, 
                                     new_desc.namespace, new_desc.package_version,
                                     str(new_desc.version))

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -285,7 +285,7 @@ class VistrailController(object):
         Change the controller file name
         
         """
-        if file_name == None:
+        if file_name is None:
             file_name = ''
         if self.file_name!=file_name:
             self.file_name = file_name

--- a/vistrails/core/vistrail/location.py
+++ b/vistrails/core/vistrail/location.py
@@ -194,6 +194,6 @@ class TestLocation(unittest.TestCase):
         a = Location(x=0, y=1)
         b = Location(x=0, y=1)
         assert a == b
-        assert a != None
+        assert a is not None
         b = Location(x=0, y=0.1)
         assert a != b

--- a/vistrails/core/vistrail/pipeline.py
+++ b/vistrails/core/vistrail/pipeline.py
@@ -989,7 +989,7 @@ class Pipeline(DBWorkflow):
         def find_descriptors(pipeline, module_ids=None):
             registry = get_module_registry()
             conf = get_vistrails_configuration()
-            if module_ids == None:
+            if module_ids is None:
                 module_ids = pipeline.modules.iterkeys()
             exceptions = set()
             for mid in module_ids:

--- a/vistrails/db/services/locator.py
+++ b/vistrails/db/services/locator.py
@@ -364,7 +364,7 @@ class SaveTemporariesMixin(object):
         latest one.
 
         """
-        if temporary == None:
+        if temporary is None:
             return self.encode_name(self.get_temp_basename()) + '0'
         else:
             split = temporary.rfind('_')+1

--- a/vistrails/db/services/prov.py
+++ b/vistrails/db/services/prov.py
@@ -427,7 +427,7 @@ def create_prov(workflow, version, log):
                     prov_usage = create_prov_usage(prov_activity, prov_input_data)
                     usages.append(prov_usage)
                 
-            if (prov_activity._db_vt_error == None) or (prov_activity._db_vt_error == ''):
+            if (prov_activity._db_vt_error is None) or (prov_activity._db_vt_error == ''):
                 if source_conn.has_key(exec_._db_module_id):
                     connections = source_conn[exec_._db_module_id]
                     for connection in connections:

--- a/vistrails/gui/collection/explorer.py
+++ b/vistrails/gui/collection/explorer.py
@@ -159,7 +159,7 @@ def getConnectionInfo(connectionList, id):
     conn = connectionList.get_connection(id)
     key = str(conn.id) + "." + conn.name + "." + conn.host
     passwd = DBLocator.keyChain.get_key(key)
-    if conn != None:
+    if conn is not None:
         config = {'id': conn.id,
                   'name': conn.name,
                   'host': conn.host,
@@ -180,7 +180,7 @@ def checkConnection(connectionList):
     if conn_id != -1:
         conn = connectionList.get_connection(conn_id)
         config = getConnectionInfo(connectionList, conn_id)
-        if config != None:
+        if config is not None:
             config_name = config['name']
             config_id = config['id']
             try:

--- a/vistrails/gui/collection/workspace.py
+++ b/vistrails/gui/collection/workspace.py
@@ -797,7 +797,7 @@ class QVistrailList(QtGui.QTreeWidget):
         Expand/Collapse top-level item when the mouse is pressed
         
         """
-        if item and item.parent() == None:
+        if item and item.parent() is None:
             self.setItemExpanded(item, not self.isItemExpanded(item))
             
     def search_result_selected(self, view, version):

--- a/vistrails/gui/module_palette.py
+++ b/vistrails/gui/module_palette.py
@@ -275,7 +275,7 @@ class QModuleTreeWidget(QSearchTreeWidget):
         Expand/Collapse top-level item when the mouse is pressed
         
         """
-        if item and item.parent() == None:
+        if item and item.parent() is None:
             self.setItemExpanded(item, not self.isItemExpanded(item))
 
     def contextMenuEvent(self, event):

--- a/vistrails/gui/modules/paramexplore.py
+++ b/vistrails/gui/modules/paramexplore.py
@@ -674,7 +674,7 @@ class QUserFunctionEditor(QtGui.QFrame):
             def evaluate(i):
                 try:
                     v = d['value'](i)
-                    if v == None:
+                    if v is None:
                         return module.default_value
                     return v
                 except Exception, e:

--- a/vistrails/gui/open_db_window.py
+++ b/vistrails/gui/open_db_window.py
@@ -379,7 +379,7 @@ class QDBConnectionList(QtGui.QListWidget):
         item = None
         if len(self.selectedItems()) > 0:
             item  = self.selectedItems()[0]
-        if item != None:
+        if item is not None:
             return int(item.id)
         else:
             return -1
@@ -404,7 +404,7 @@ class QDBConnectionList(QtGui.QListWidget):
         """
         conn_id = self.getCurrentItemId()
         config = self.getConnectionInfo(conn_id)
-        if config != None:
+        if config is not None:
             config["create"] = False
             self.parent().showConnConfig(**config)
             
@@ -436,7 +436,7 @@ class QDBConnectionList(QtGui.QListWidget):
         conn = self.__list.get_connection(id)
         key = str(conn.id) + "." + conn.name + "." + conn.host
         passwd = DBLocator.keyChain.get_key(key)
-        if conn != None:
+        if conn is not None:
             config = {'id': conn.id,
                       'name': conn.name,
                       'host': conn.host,
@@ -602,7 +602,7 @@ class QDBObjectList(QtGui.QListWidget):
                     debug.critical('An error has occurred', e)
                     raise e
                 config = parent.connectionList.getConnectionInfo(int(conn_id))
-                if config != None:
+                if config is not None:
                     config["create"] = False
                     if not parent.showConnConfig(**config):
                         raise e

--- a/vistrails/gui/paramexplore/pe_view.py
+++ b/vistrails/gui/paramexplore/pe_view.py
@@ -93,7 +93,7 @@ class QParamExploreView(QParameterExplorationWidget, BaseView):
     def set_execute_action(self):
         if self.controller and self.controller.vistrail:
             versionId = self.controller.current_version
-            return self.controller.vistrail.get_paramexp(versionId) != None
+            return self.controller.vistrail.get_paramexp(versionId) is not None
         return False
     
     def explore_non_empty(self, on):

--- a/vistrails/gui/pipeline_view.py
+++ b/vistrails/gui/pipeline_view.py
@@ -3684,7 +3684,7 @@ class QPipelineView(QInteractiveGraphicsView, BaseView):
     def set_controller(self, controller):
         oldController = self.controller
         if oldController != controller:
-            #if oldController != None:
+            #if oldController is not None:
                 # self.disconnect(oldController,
                 #                 QtCore.SIGNAL('versionWasChanged'),
                 #                 self.version_changed)

--- a/vistrails/gui/version_view.py
+++ b/vistrails/gui/version_view.py
@@ -131,8 +131,8 @@ class QGraphicsLinkItem(QGraphicsItemInterface, QtGui.QGraphicsPolygonItem):
 
         # check if it is the same geometry 
         # improves performance on updates
-        if self.c1 != None and self.c2 != None and \
-                self.expand != None and self.collapse !=None:
+        if self.c1 is not None and self.c2 is not None and \
+                self.expand is not None and self.collapse !=None:
             isTheSame = self.c1 == c1 and \
                 self.c2 == c2 and \
                 self.expand == expand and \
@@ -1256,7 +1256,7 @@ class QVersionTreeView(QInteractiveGraphicsView, BaseView):
     def set_controller(self, controller):
         oldController = self.controller
         if oldController != controller:
-            if oldController != None:
+            if oldController is not None:
                 self.disconnect(oldController,
                                 QtCore.SIGNAL('vistrailChanged()'),
                                 self.vistrailChanged)

--- a/vistrails/gui/vistrail_controller.py
+++ b/vistrails/gui/vistrail_controller.py
@@ -1019,7 +1019,7 @@ class VistrailController(QtCore.QObject, BaseController):
         self.invalidate_version_tree(False)
 
     def get_pipeline_name(self, version=None):
-        if version == None:
+        if version is None:
             version = self.current_version
         return self.vistrail.get_pipeline_name(version)
 

--- a/vistrails/gui/vistrails_window.py
+++ b/vistrails/gui/vistrails_window.py
@@ -2255,7 +2255,7 @@ class QVistrailsWindow(QVistrailViewWindow):
             action.setCheckable(True)
             
             base_view_windows = {}
-            if current_view == None or \
+            if current_view is None or \
                QtGui.QApplication.activeWindow() == self:
                 action.setChecked(True)
             actions.append(action)

--- a/vistrails/packages/RemoteQ/streaming.py
+++ b/vistrails/packages/RemoteQ/streaming.py
@@ -81,7 +81,7 @@ class HadoopStreaming(HadoopBaseModule):
         if p['workdir']==None:
             p['workdir'] = ".vistrails-hadoop"
         p['job_identifier'] = self.force_get_input('Identifier')
-        if p['job_identifier'] == None:
+        if p['job_identifier'] is None:
             raise ModuleError(self, 'Job Identifier is required')
         p['input'] = self.force_get_input('Input')
         p['output'] = self.force_get_input('Output')

--- a/vistrails/packages/matplotlib/parse.py
+++ b/vistrails/packages/matplotlib/parse.py
@@ -380,12 +380,12 @@ def parse_translation(rows, should_reverse=True):
         (val1, port_type1) = get_value_and_type(row[0])
         (val2, port_type2) = get_value_and_type(row[1])
         if should_reverse:
-            if val2 != None:
+            if val2 is not None:
                 port_types.append(port_type2)
                 values.append(val2)
                 t[val2] = val1
         else:
-            if val1 != None:
+            if val1 is not None:
                 port_types.append(port_type1)
                 values.append(val1)
                 t[val1] = val2

--- a/vistrails/packages/spreadsheet/spreadsheet_cell.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_cell.py
@@ -455,7 +455,7 @@ class QCellToolBarSelectedCell(QtGui.QAction):
 
         """
         (sheet, row, col, cellWidget) = info
-        self.setVisible(cellWidget != None)
+        self.setVisible(cellWidget is not None)
 
 class QCellToolBarRemoveCell(QCellToolBarSelectedCell):
     """

--- a/vistrails/packages/vtk/base_module.py
+++ b/vistrails/packages/vtk/base_module.py
@@ -108,9 +108,9 @@ class vtkBaseModule(Module):
 
         pp = []
         for j in xrange(len(setterSig)):
-            setter = list(setterSig[j][1]) if setterSig[j][1] != None else None
+            setter = list(setterSig[j][1]) if setterSig[j][1] is not None else None
             aux = []
-            if setter != None and len(setter) == len(params) and pp == []:
+            if setter is not None and len(setter) == len(params) and pp == []:
                 for i in xrange(len(setter)):
                     if setter[i].find('[') != -1:
                         del aux[:]

--- a/vistrails/packages/vtk/init.py
+++ b/vistrails/packages/vtk/init.py
@@ -330,7 +330,7 @@ def prune_signatures(module, name, signatures, output=False):
                 c = curr.replace('[', '')
                 c = c.replace(']', '')
                 result.append(c)
-            elif (curr == None):
+            elif (curr is None):
                 result.append(curr)
             elif (isinstance(curr, list)):
                 curr.reverse()

--- a/vistrails/packages/vtk/init.py
+++ b/vistrails/packages/vtk/init.py
@@ -872,56 +872,56 @@ def class_dict(base_module, node):
         return compute
 
     def compute_SetDiffuseColorWidget(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetDiffuseColorWidget(self, color):
             self.vtkInstance.SetDiffuseColor(color.tuple)
         return call_SetDiffuseColorWidget
 
     def compute_SetAmbientColorWidget(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetAmbientColorWidget(self, color):
             self.vtkInstance.SetAmbientColor(color.tuple)
         return call_SetAmbientColorWidget
 
     def compute_SetSpecularColorWidget(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetSpecularColorWidget(self, color):
             self.vtkInstance.SetSpecularColor(color.tuple)
         return call_SetSpecularColorWidget
 
     def compute_SetColorWidget(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetColorWidget(self, color):
             self.vtkInstance.SetColor(color.tuple)
         return call_SetColorWidget
 
     def compute_SetEdgeColorWidget(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetEdgeColorWidget(self, color):
             self.vtkInstance.SetEdgeColor(color.tuple)
         return call_SetEdgeColorWidget
     
     def compute_SetBackgroundWidget(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetBackgroundWidget(self, color):
             self.vtkInstance.SetBackground(color.tuple)
         return call_SetBackgroundWidget
     
     def compute_SetBackground2Widget(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetBackground2Widget(self, color):
             self.vtkInstance.SetBackground2(color.tuple)
         return call_SetBackground2Widget
     
     def compute_SetVTKCell(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetRenderWindow(self, cellObj):
             if cellObj.cellWidget:
@@ -930,28 +930,28 @@ def class_dict(base_module, node):
     
     def compute_SetTransferFunction(old_compute):
         # This sets the transfer function
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetTransferFunction(self, tf):
             tf.set_on_vtk_volume_property(self.vtkInstance)
         return call_SetTransferFunction
 
     def compute_SetPointData(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetPointData(self, pd):
             self.vtkInstance.GetPointData().ShallowCopy(pd)
         return call_SetPointData
 
     def compute_SetCellData(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetCellData(self, cd):
             self.vtkInstance.GetCellData().ShallowCopy(cd)
         return call_SetCellData            
 
     def compute_SetPointIds(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_SetPointIds(self, point_ids):
             self.vtkInstance.GetPointIds().SetNumberOfIds(point_ids.GetNumberOfIds())
@@ -960,7 +960,7 @@ def class_dict(base_module, node):
         return call_SetPointIds
 
     def compute_CopyImportString(old_compute):
-        if old_compute != None:
+        if old_compute is not None:
             return old_compute
         def call_CopyImportVoidPointer(self, pointer):
             self.vtkInstance.CopyImportVoidPointer(pointer, len(pointer))
@@ -987,7 +987,7 @@ def class_dict(base_module, node):
         if set_file_name_pattern.match(var):
             def get_compute_SetFile(method_name):
                 def compute_SetFile(old_compute):
-                    if old_compute != None:
+                    if old_compute is not None:
                         return old_compute
                     def call_SetFile(self, file_obj):
                         getattr(self.vtkInstance, method_name)(file_obj.name)

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -247,7 +247,7 @@ class QVTKWidget(QCellWidget):
             renderers = [renderView.vtkInstance.GetRenderer()]
         self.renderer_maps = {}
         self.usecameras = False
-        if cameralist != None and len(cameralist) == len(renderers):
+        if cameralist is not None and len(cameralist) == len(renderers):
             self.usecameras = True
         j = 0
         for renderer in renderers:

--- a/vistrails/packages/webServices/init.py
+++ b/vistrails/packages/webServices/init.py
@@ -125,7 +125,7 @@ def webServiceTypesDict(WBobj):
             nameattrib = nameattrib[0].upper() + nameattrib[1:]
             sentence = "visobj" + "." + nameattrib
             visdata = eval(sentence)
-            if visdata != None:
+            if visdata is not None:
                 try:
                     Type = wsdlTypesDict[str(typechild)]
                     setattr(libobj,nameattrib,visdata)
@@ -148,7 +148,7 @@ def webServiceTypesDict(WBobj):
                 nameattribute = nameattrib[0].upper() + nameattrib[1:]
                 sentence = "visobj" + "." + nameattribute
                 visdata = eval(sentence)
-                if visdata != None:
+                if visdata is not None:
                     nameattrib = "attribute_typecode_dict[" + nameattrib + "].pname"
                     setattr(libobj,nameattrib,visdata)
 
@@ -574,7 +574,7 @@ def processType(complexschema,w):
             contentschema = complexschema.content.content
     try:       
         #Get all the attributes of the complex type
-        if complexschema.attr_content != None:
+        if complexschema.attr_content is not None:
             for attribute in complexschema.attr_content:
                 nametype = attribute.getAttributeName()
                 Type = 'string'
@@ -1335,7 +1335,7 @@ def verify_wsdl(wsdlList):
         response = conn.getresponse()
         remoteHeader = response.msg.getheader('last-modified')
         isoutdated = False
-        if remoteHeader != None:
+        if remoteHeader is not None:
             localFile = client_file
             reg = vistrails.core.modules.module_registry.get_module_registry()
             httpfile = reg.get_descriptor_by_name(

--- a/vistrails/packages/webServices/init.py
+++ b/vistrails/packages/webServices/init.py
@@ -330,7 +330,7 @@ def webServiceParamsMethodDict(name, server, inparams, outparams):
         if isinstance(resp, list):
             ptype = resp[0].typecode.type[1]
         else:
-            if resp.typecode.type[1] == None:
+            if resp.typecode.type[1] is None:
                 ptype = resp.typecode.pname
             else:    
                 ptype = resp.typecode.type[1]
@@ -550,12 +550,12 @@ def processType(complexschema,w):
 
     if complexschema.isElement():
         try:
-            if complexschema.content.content == None:
+            if complexschema.content.content is None:
                 contentschema = []
             else:    
                 contentschema = complexschema.content.content.content
             objModule.typeobj = 'ComplexType'
-            if (complexschema.content.content == None or
+            if (complexschema.content.content is None or
                 complexschema.content.content.content == ()):
                 objModule.isEmptySequence = True
         except AttributeError:
@@ -1345,7 +1345,7 @@ def verify_wsdl(wsdlList):
             except OSError:
                 print "File doesn't exist"
                 isoutdated = True
-        if isoutdated or remoteHeader == None:
+        if isoutdated or remoteHeader is None:
             outdated_list.append(w)
         else:
             updated_list.append(w)


### PR DESCRIPTION
Goes further than 1a68f107 (which was displaying a warning, if PythonSource was outputting a numpy array) and replace these unsafe constructs, `!= None` and `== None`, everywhere.