### PR TITLE
Moves ITK docs from developer's to user's guide

### DIFF
--- a/doc/usersguide/developer.rst
+++ b/doc/usersguide/developer.rst
@@ -10,7 +10,6 @@ Developer's Guide
    packages
    batch
    log
-   example_itk
    controlflowdev
    parallelization
    cltools

--- a/doc/usersguide/example.rst
+++ b/doc/usersguide/example.rst
@@ -56,6 +56,7 @@ Intermediate Concepts and VisTrails Packages
    parallelflow
    database
    example_webservices
+   example_itk
    persistence
    vistrails_server
    latex


### PR DESCRIPTION
I'm not sure about the status of ITK, it doesn't appear to have moved much since 2009.