### PR TITLE
Highlight unset ports in input ports list

### DIFF
--- a/vistrails/gui/ports_pane.py
+++ b/vistrails/gui/ports_pane.py
@@ -321,7 +321,9 @@ class PortItem(QtGui.QTreeWidgetItem):
         self.is_optional = is_optional
         self.is_visible = is_visible
         self.is_editable = is_editable
-        self.build_item(port_spec, is_connected, is_optional, is_visible, is_editable)
+        self.is_unset = False
+        self.build_item(port_spec, is_connected, is_optional, is_visible,
+                        is_editable)
 
     def visible(self):
         return not self.is_optional or self.is_visible
@@ -349,6 +351,16 @@ class PortItem(QtGui.QTreeWidgetItem):
     def is_constant(self):
         return (self.port_spec.is_valid and 
                 get_module_registry().is_constant(self.port_spec))
+
+    def calcUnset(self):
+        self.is_unset = self.is_constant() and \
+                        self.port_spec.is_mandatory() and \
+                        not self.is_connected and \
+                        not self.isExpanded()
+        if self.is_unset:
+            font = self.font(3)
+            font.setWeight(QtGui.QFont.Bold)
+            self.setFont(3, font)
 
     def build_item(self, port_spec, is_connected, is_optional, is_visible, is_editable):
         if not is_optional:
@@ -398,7 +410,10 @@ class PortItem(QtGui.QTreeWidgetItem):
         widget.setAttribute(QtCore.Qt.WA_DeleteOnClose)
         widget.exec_()
 
-    def __lt__( self, other ):
+    def __lt__(self, other):
+        # put unset mandatory ports first
+        if self.is_unset != other.is_unset:
+            return self.is_unset and not other.is_unset
         # put set (expanded) functions first
         if self.isExpanded() != other.isExpanded():
             return self.isExpanded() and not other.isExpanded()
@@ -488,7 +503,7 @@ class PortsList(QtGui.QTreeWidget):
                     subitem.setFirstColumnSpanned(True)
                     self.setItemWidget(subitem, 2, subitem.get_widget())
                     item.setExpanded(True)
-                
+
                     # self.setItemWidget(item, 0, item.get_visible())
                     # self.setItemWidget(item, 1, item.get_connected())
 
@@ -500,9 +515,12 @@ class PortsList(QtGui.QTreeWidget):
                     # connceted_checkbox = QtGui.QCheckBox()
                     # connected_checkbox.setEnabled(False)
                     # self.setItemWidget(i, 1, connected_checkbox)
-                self.sortItems(0, QtCore.Qt.AscendingOrder)
 
-                
+                # Highlight unset ports
+                for _, item  in self.port_spec_items.itervalues():
+                    item.calcUnset()
+
+                self.sortItems(0, QtCore.Qt.AscendingOrder)
 
             # base_items = {}
             # # Create the base widget item for each descriptor


### PR DESCRIPTION
"Unset" ports are mandatory constant ports (min_conn>0) that are
not set and not connected

This commit moves them to the top of the ports list and
makes them bold (like their module port counterpart).

gui/ports_pane.py:
 - PortItem:
   New attribute: is_unset
 - PortItem.calcUnset: *new
   Determines if the port is unset and makes it bold
 - PortItem.\__lt\__:
   Move unset items to the top