### PR TITLE
Fix vtkcell on X11 for VTK >=6.2

### DIFF
--- a/vistrails/packages/vtk/init.py
+++ b/vistrails/packages/vtk/init.py
@@ -163,6 +163,9 @@ def get_method_signature(method, docum='', name=''):
 
     """
     doc = docum or method.__doc__
+    if not doc:
+        debug("Ignoring method %r, no __doc__" % method)
+        return []
     doc = doc.split('\n')
     tmp = []
     for l in doc:

--- a/vistrails/packages/vtk/init.py
+++ b/vistrails/packages/vtk/init.py
@@ -162,10 +162,10 @@ def get_method_signature(method, docum='', name=''):
     Re-wrap Prabu's method to increase performance
 
     """
-    doc = method.__doc__ if docum=='' else docum
-    tmptmp = doc.split('\n')
+    doc = docum or method.__doc__
+    doc = doc.split('\n')
     tmp = []
-    for l in tmptmp:
+    for l in doc:
         l = l.strip('\n \t')
         if l.startswith('V.') or l.startswith('C++:'):
             tmp.append(l)
@@ -219,7 +219,7 @@ def get_method_signature(method, docum='', name=''):
                     arg = [arg]
 
             sig.append(([ret], arg))
-    return sig    
+    return sig
 
 def prune_signatures(module, name, signatures, output=False):
     """prune_signatures tries to remove redundant signatures to reduce

--- a/vistrails/packages/vtk/vtk_parser.py
+++ b/vistrails/packages/vtk/vtk_parser.py
@@ -363,7 +363,10 @@ class VTKMethodParser(object):
         meths = self._find_state_methods(klass, meths)
         meths = self._find_get_set_methods(klass, meths)
         meths = self._find_get_methods(klass, meths)
-        self.other_meths = [x for x in meths if '__' not in x]
+        self.other_meths = [x for x in meths \
+                            if callable(getattr(klass, x)) and
+                                '__' not in x and
+                                not isinstance(getattr(klass, x), type)]
 
     def _remove_method(self, meths, method):
         try:

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -327,21 +327,25 @@ class QVTKWidget(QCellWidget):
             if self.mRenWin.GetMapped():
                 self.mRenWin.Finalize()
             if system.systemType=='Linux':
-                vp = None
+                display = None
                 try:
-                    vp = '_%s_void_p' % (hex(int(QtGui.QX11Info.display()))[2:])
+                    display = int(QtGui.QX11Info.display())
                 except TypeError:
-                    #This was change for PyQt4.2
-                    if isinstance(QtGui.QX11Info.display(),QtGui.Display):
+                    # This was changed for PyQt4.2
+                    if isinstance(QtGui.QX11Info.display(), QtGui.Display):
                         display = sip.unwrapinstance(QtGui.QX11Info.display())
-                        vp = '_%s_void_p' % (hex(display)[2:])
-                if vp is not None:
+                if display is not None:
                     v = vtk.vtkVersion()
                     version = [v.GetVTKMajorVersion(),
                                v.GetVTKMinorVersion(),
                                v.GetVTKBuildVersion()]
+                    display = hex(display)[2:]
                     if version < [5, 7, 0]:
-                        vp = vp + '\0x00'
+                        vp = ('_%s_void_p\0x00' % display)
+                    elif version < [6, 2, 0]:
+                        vp = ('_%s_void_p' % display)
+                    else:
+                        vp = ('_%s_p_void' % display)
                     self.mRenWin.SetDisplayId(vp)
                 self.resizeWindow(1,1)
             self.mRenWin.SetWindowInfo(str(int(self.winId())))


### PR DESCRIPTION
This changes vtkcell to use the correct SWIG pointer format required by VTK >=6.2.

Untested since I have VTK 5.10.

UV-CDAT issue: UV-CDAT/uvcdat#1019
UV-CDAT PR: UV-CDAT/VisTrails#16