### PR TITLE
Switchs order of output ports

### DIFF
--- a/vistrails/core/modules/module_registry.py
+++ b/vistrails/core/modules/module_registry.py
@@ -820,7 +820,7 @@ class ModuleRegistry(DBRegistry):
             ports.update(self.module_ports('output', desc))
         all_ports = ports.values()
         if do_sort:
-            all_ports.sort(key=lambda x: (x.sort_key, x.id))
+            all_ports.sort(key=lambda x: (-x.sort_key, x.id))
         return all_ports        
 
     def module_source_ports(self, do_sort, identifier, module_name, 

--- a/vistrails/core/modules/module_registry.py
+++ b/vistrails/core/modules/module_registry.py
@@ -820,7 +820,7 @@ class ModuleRegistry(DBRegistry):
             ports.update(self.module_ports('output', desc))
         all_ports = ports.values()
         if do_sort:
-            all_ports.sort(key=lambda x: (-x.sort_key, x.id))
+            all_ports.sort(key=lambda x: (x.sort_key, x.id))
         return all_ports        
 
     def module_source_ports(self, do_sort, identifier, module_name, 

--- a/vistrails/core/vistrail/module.py
+++ b/vistrails/core/vistrail/module.py
@@ -243,7 +243,7 @@ class Module(DBModule):
     input_port_specs = property(_get_input_port_specs)
     def _get_output_port_specs(self):
         return sorted(self._output_port_specs, 
-                      key=lambda x: (-x.sort_key, x.id))
+                      key=lambda x: (x.sort_key, x.id))
     output_port_specs = property(_get_output_port_specs)
 
     def _get_descriptor_info(self):

--- a/vistrails/core/vistrail/module.py
+++ b/vistrails/core/vistrail/module.py
@@ -243,7 +243,7 @@ class Module(DBModule):
     input_port_specs = property(_get_input_port_specs)
     def _get_output_port_specs(self):
         return sorted(self._output_port_specs, 
-                      key=lambda x: (x.sort_key, x.id), reverse=True)
+                      key=lambda x: (-x.sort_key, x.id))
     output_port_specs = property(_get_output_port_specs)
 
     def _get_descriptor_info(self):

--- a/vistrails/gui/pipeline_view.py
+++ b/vistrails/gui/pipeline_view.py
@@ -1555,7 +1555,7 @@ class QGraphicsModuleItem(QGraphicsItemInterface, QtGui.QGraphicsItem):
 
         # Update output ports
         [x, y] = self.nextOutputPortPos
-        for port in outputPorts:            
+        for port in reversed(outputPorts):
             self.outputPorts[port] = self.createPortItem(port, x, y)
             x -= t.PORT_WIDTH + t.MODULE_PORT_SPACE
         self.nextOutputPortPos = [x, y]

--- a/vistrails/packages/sklearn/init.py
+++ b/vistrails/packages/sklearn/init.py
@@ -39,8 +39,8 @@ class Digits(Module):
     """Example dataset: digits.
     """
     _settings = ModuleSettings(namespace="datasets")
-    _output_ports = [("data", "basic:List", {'sort_key': 1, 'shape': 'circle'}),
-                     ("target", "basic:List", {'sort_key': 0, 'shape': 'circle'})]
+    _output_ports = [("data", "basic:List", {'shape': 'circle'}),
+                     ("target", "basic:List", {'shape': 'circle'})]
 
     def compute(self):
         data = datasets.load_digits()
@@ -52,8 +52,8 @@ class Iris(Module):
     """Example dataset: iris.
     """
     _settings = ModuleSettings(namespace="datasets")
-    _output_ports = [("data", "basic:List", {'sort_key': 1, 'shape': 'circle'}),
-                     ("target", "basic:List", {'sort_key': 0, 'shape': 'circle'})]
+    _output_ports = [("data", "basic:List", {'shape': 'circle'}),
+                     ("target", "basic:List", {'shape': 'circle'})]
 
     def compute(self):
         data = datasets.load_iris()
@@ -140,13 +140,13 @@ class Transform(Module):
 class TrainTestSplit(Module):
     """Split data into training and testing randomly."""
     _settings = ModuleSettings(namespace="cross-validation")
-    _input_ports = [("data", "basic:List", {'sort_key': 0, 'shape': 'circle'}),
-                    ("target", "basic:List", {'sort_key': 1, 'shape': 'circle'}),
-                    ("test_size", "basic:Float", {"defaults": [.25], 'sort_key': 2})]
-    _output_ports = [("training_data", "basic:List", {'sort_key': 3, 'shape': 'circle'}),
-                     ("training_target", "basic:List", {'sort_key': 2, 'shape': 'circle'}),
-                     ("test_data", "basic:List", {'sort_key': 1, 'shape': 'circle'}),
-                     ("test_target", "basic:List", {'sort_key': 0, 'shape': 'circle'})]
+    _input_ports = [("data", "basic:List", {'shape': 'circle'}),
+                    ("target", "basic:List", {'shape': 'circle'}),
+                    ("test_size", "basic:Float", {"defaults": [.25]})]
+    _output_ports = [("training_data", "basic:List", {'shape': 'circle'}),
+                     ("training_target", "basic:List", {'shape': 'circle'}),
+                     ("test_data", "basic:List", {'shape': 'circle'}),
+                     ("test_target", "basic:List", {'shape': 'circle'})]
 
     def compute(self):
         X_train, X_test, y_train, y_test = \
@@ -183,12 +183,12 @@ class CrossValScore(Module):
 
 class GridSearchCV(Estimator):
     """Perform cross-validated grid-search over a parameter grid."""
-    _input_ports = [("model", "Estimator", {'sort_key': 0, 'shape': 'diamond'}),
-                    ("parameters", "basic:Dictionary", {'sort_key': 1}),
-                    ("data", "basic:List", {'sort_key': 2, 'shape': 'circle'}),
-                    ("target", "basic:List", {'sort_key': 3, 'shape': 'circle'}),
-                    ("metric", "basic:String", {"defaults": ["accuracy"], 'sort_key': 4}),
-                    ("folds", "basic:Integer", {"defaults": ["3"], 'sort_key': 5})]
+    _input_ports = [("model", "Estimator", {'shape': 'diamond'}),
+                    ("parameters", "basic:Dictionary"),
+                    ("data", "basic:List", {'shape': 'circle'}),
+                    ("target", "basic:List", {'shape': 'circle'}),
+                    ("metric", "basic:String", {"defaults": ["accuracy"]}),
+                    ("folds", "basic:Integer", {"defaults": ["3"]})]
     _output_ports = [("scores", "basic:List"), ("model", "Estimator", {'shape': 'diamond'}),
                      ("best_parameters", "basic:Dictionary"),
                      ("best_score", "basic:Float")]
@@ -211,13 +211,11 @@ class GridSearchCV(Estimator):
 
 class Pipeline(Estimator):
     """Chain estimators to form a pipeline."""
-    _input_ports = [("model1", "Estimator", {'shape': 'diamond', 'sort_key': 2}),
-                    ("model2", "Estimator", {'optional': True, 'shape': 'diamond', 'sort_key': 3}),
-                    ("model3", "Estimator", {'optional': True, 'shape': 'diamond', 'sort_key': 4}),
-                    ("model4", "Estimator", {'optional': True, 'shape': 'diamond', 'sort_key': 5}),
-                    ("training_data", "basic:List", {'shape': 'circle', 'sort_key': 0}),
-                    ("training_target", "basic:List", {'shape': 'circle', 'sort_key': 1}),
-                    ]
+    _input_ports = [("training_data", "basic:List", {'shape': 'circle'}),
+                    ("training_target", "basic:List", {'shape': 'circle'}),("model1", "Estimator", {'shape': 'diamond'}),
+                    ("model2", "Estimator", {'optional': True, 'shape': 'diamond'}),
+                    ("model3", "Estimator", {'optional': True, 'shape': 'diamond'}),
+                    ("model4", "Estimator", {'optional': True, 'shape': 'diamond'})]
 
     def compute(self):
         models = ["model%d" % d for d in range(1, 5)]
@@ -273,9 +271,9 @@ class ROCCurve(Module):
 # Classifiers and Regressors
 
 def make_module(name, Estimator, namespace, supervised=False, Base=None):
-    input_ports = [("training_data", "basic:List", {'sort_key': 0, 'shape': 'circle'})]
+    input_ports = [("training_data", "basic:List", {'shape': 'circle'})]
     if supervised:
-        input_ports.append(("training_target", "basic:List", {'sort_key': 1, 'shape': 'circle'}))
+        input_ports.append(("training_target", "basic:List", {'shape': 'circle'}))
     est = Estimator()
     input_ports.extend([(param, "basic:String", {'optional': True}) for param
                         in est.get_params()])


### PR DESCRIPTION
This draws output ports from left to right, ordering them **in descending order of sort_keys** when provided. Input port are still sorted by ascending order of sort_keys. This should keep the order of output ports if the package author bothered to provide sort_keys, else it will change the order to match the declaration order. Hence it is surprising.

My test case is this: https://gist.github.com/remram44/f1a459fd3452cbc120d1

Highlighted connections are between port specs, not module ports.

master:
![](http://i.imgur.com/dHpfBWX.png)
There is something strange going on in the ordering of port specs with the same sort_key. I didn't bother keeping compatibility there.

This PR:
![](http://i.imgur.com/EjQ6C8q.png)

Note that sort keys are backwards for both FixedOrder#_output_ports, and the sort_keys in ports.xml. This is for compatibility reasons.

This means that a PythonSource's output ports are still drawn from right to left, because sort_keys are assigned to them, in ascending order.

Fixes #980