### PR TITLE
TableOutput module, TableToFileMode mode, CSV format?

### DIFF
--- a/vistrails/packages/tabledata/common.py
+++ b/vistrails/packages/tabledata/common.py
@@ -268,6 +268,7 @@ class SingleColumnTable(Converter):
     """
     _input_ports = [('in_value', List)]
     _output_ports = [('out_value', Table)]
+
     def compute(self):
         column = self.get_input('in_value')
         if not isinstance(column, ListType):
@@ -277,9 +278,12 @@ class SingleColumnTable(Converter):
                 len(column),            # nb_rows
                 ['converted_list']))    # names
 
+
 class TableToFileMode(FileMode):
-    formats = ['html']
-    def write_html(self, table):
+    formats = ['html', 'csv']
+
+    @staticmethod
+    def make_html(table):
         document = ['<!DOCTYPE html>\n'
                     '<html>\n  <head>\n'
                     '    <meta http-equiv="Content-type" content="text/html; '
@@ -312,16 +316,33 @@ class TableToFileMode(FileMode):
 
         return ''.join(document)
 
-    def compute_output(self, output_module, configuration=None):
-        value = output_module.get_input("value")
+    def write_html(self, table, configuration):
         filename = self.get_filename(configuration, suffix='.html')
         with open(filename, 'wb') as fp:
-            fp.write(self.write_html(value))
+            fp.write(self.make_html(table))
+
+    def write_csv(self, table, configuration):
+        from .write.write_csv import WriteCSV
+
+        filename = self.get_filename(configuration, suffix='.csv')
+        WriteCSV.write(filename, table)
+
+    def compute_output(self, output_module, configuration=None):
+        value = output_module.get_input("value")
+        format = configuration.get('format', 'html').lower()
+        try:
+            func = getattr(self, 'write_%s' % format)
+        except AttributeError:
+            raise AttributeError("TableToFileMode: unknown format %s" % format)
+        else:
+            func(value, configuration)
+
 
 class TableOutput(OutputModule):
     _settings = ModuleSettings(configure_widget="vistrails.gui.modules.output_configuration:OutputModuleConfigurationWidget")
     _input_ports = [('value', 'Table')]
     _output_modes = [TableToFileMode]
+
 
 _modules = [(Table, {'abstract': True}), ExtractColumn, BuildTable,
             (SingleColumnTable, {'hide_descriptor': True}),

--- a/vistrails/packages/tabledata/write/write_csv.py
+++ b/vistrails/packages/tabledata/write/write_csv.py
@@ -23,6 +23,20 @@ class WriteCSV(Module):
              {'optional': True})]
     _output_ports = [('file', '(org.vistrails.vistrails.basic:File)')]
 
+    @staticmethod
+    def write(fname, table, delimiter=';', write_header=True):
+        with open(fname, 'w') as fp:
+            if write_header and table.names is not None:
+                fp.write(delimiter.join(table.names) + '\n')
+
+            cols = [table.get_column(i) for i in xrange(table.columns)]
+            line = 0
+            for l in izip(*cols):
+                fp.write(delimiter.join(str(e) for e in l) + '\n')
+                line += 1
+
+        return line
+
     def compute(self):
         table = self.get_input('table')
         delimiter = self.get_input('delimiter')
@@ -33,30 +47,24 @@ class WriteCSV(Module):
             write_header = self.force_get_input('write_header')
             if write_header is not False:
                 if table.names is None:
-                    if write_header is True: # pragma: no cover
+                    if write_header is True:  # pragma: no cover
                         raise ModuleError(
                                 self,
                                 "write_header is set but the table doesn't "
                                 "have column names")
-                else:
-                    fp.write(delimiter.join(table.names) + '\n')
 
-            cols = [iter(table.get_column(i)) for i in xrange(table.columns)]
-
-            if not cols:
+            if not table.columns:
                 raise ModuleError(
                         self,
                         "Table has no columns")
 
-            line = 0
-            for l in izip(*cols):
-                fp.write(delimiter.join(str(e) for e in l) + '\n')
-                line += 1
+            nb_lines = self.write(fname, table, delimiter,
+                                  write_header is not False)
 
             rows = table.rows
-            if line != rows: # pragma: no cover
+            if nb_lines != rows:  # pragma: no cover
                 debug.warning("WriteCSV wrote %d lines instead of expected "
-                              "%d" % (line, rows))
+                              "%d" % (nb_lines, rows))
 
         self.set_output('file', fileobj)
 


### PR DESCRIPTION
I'm playing with the output modes system in view of integrating it with the new API (it's the last point on #24).

I wrote this, however it seems that the "format" option is global to FileMode, not just TableToFileMode.

If this is intended, i.e. FileMode means "user-readable file of any type", then having a "csv" format doesn't make sense (but "md" or "txt" might).

Another idea might be to accept a list of formats in "formats", in order of preference, and to use the first supported one?