### PR TITLE
FileOutput format combo

### DIFF
--- a/vistrails/core/modules/output_modules.py
+++ b/vistrails/core/modules/output_modules.py
@@ -564,10 +564,13 @@ class IPythonHtmlMode(IPythonMode):
         value = output_module.get_input('value')
         display(HTML(filename=value.name))
 
+class RichTextToFileMode(FileToFileMode):
+    formats = ['html']
+
 class RichTextOutput(OutputModule):
     _settings = ModuleSettings(configure_widget="vistrails.gui.modules.output_configuration:OutputModuleConfigurationWidget")
     _input_ports = [('value', 'File')]
-    _output_modes = [FileToFileMode, IPythonHtmlMode]
+    _output_modes = [RichTextToFileMode, IPythonHtmlMode]
 
 _modules = [OutputModule, GenericOutput, FileOutput, RichTextOutput]
 

--- a/vistrails/core/modules/output_modules.py
+++ b/vistrails/core/modules/output_modules.py
@@ -17,6 +17,10 @@ class OutputMode(object):
     def can_compute():
         return False
 
+    @classmethod
+    def get_config(cls):
+        return cls.config_cls
+
     def compute_output(self, output_module, configuration=None):
         raise NotImplementedError("Subclass of OutputMode should implement "
                                   "this")
@@ -245,8 +249,8 @@ class OutputModule(NotCacheable, Module):
         for c in reversed(cls_list):
             c.ensure_mode_dict()
 
-    def get_mode_config(self, mode_cls):
-        mode_config_cls = mode_cls.config_cls
+    def get_mode_config(self, mode):
+        mode_config_cls = mode.get_config()
         mode_config_dict = {}
         configuration = self.force_get_input('configuration')
         if configuration is not None:
@@ -292,11 +296,11 @@ class OutputModule(NotCacheable, Module):
             raise ModuleError(self, "No output mode is valid, output cannot "
                               "be generated")
 
-        mode_config = self.get_mode_config(mode_cls)
         mode = mode_cls()
+        mode_config = self.get_mode_config(mode)
         self.annotate({"output_mode": mode.mode_type})
         mode.compute_output(self, mode_config)
-                
+
 class StdoutModeConfig(OutputModeConfig):
     mode_type = "stdout"
     _fields = []

--- a/vistrails/gui/modules/output_configuration.py
+++ b/vistrails/gui/modules/output_configuration.py
@@ -196,7 +196,7 @@ class OutputModeConfigurationWidget(QtGui.QGroupBox):
                 self.add_field(group_layout, dummy_field, mode_config,
                                         k)
         else:
-            for field in mode.config_cls.get_all_fields():
+            for field in mode.get_config().get_all_fields():
                 self.add_field(group_layout, field, mode_config, 
                                mode.mode_type)
         self.setLayout(group_layout)

--- a/vistrails/packages/spreadsheet/spreadsheet_cell.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_cell.py
@@ -285,11 +285,11 @@ class QCellWidget(QtGui.QWidget):
         return None
 
     def save_via_file_output(self, filename, mode_cls, save_format=None):
-        mode_config = self._output_module.get_mode_config(mode_cls)
+        mode = mode_cls()
+        mode_config = self._output_module.get_mode_config(mode)
         mode_config['file'] = filename
         if save_format is not None:
             mode_config['format'] = save_format
-        mode = mode_cls()
         mode.compute_output(self._output_module, mode_config)
 
 


### PR DESCRIPTION
Fixes #1011

This is very weird because it actually generates new `OutputModeConfig` subclasses via `type()` with a single 'format' field in `_fields` that has the correct `allowed_values`.