### PR TITLE
Module upgrades for output modules

### DIFF
--- a/vistrails/core/upgradeworkflow.py
+++ b/vistrails/core/upgradeworkflow.py
@@ -103,6 +103,15 @@ class UpgradeModuleRemap(object):
             self._control_param_remap = control_param_remap
 
     @classmethod
+    def __copy__(cls, obj):
+        newobj = cls()
+        for k, v in obj.__dict__.iteritems():
+            if k.startswith('_') and k.endswith('_remap'):
+                v = copy.copy(v)
+            newobj.__dict__[k] = v
+        return newobj
+
+    @classmethod
     def from_tuple(cls, module_name, t):
         if len(t) == 3:
             obj = cls(t[0], t[1], None, t[2], module_name=module_name)
@@ -173,7 +182,14 @@ class UpgradeModuleRemap(object):
 
 class UpgradePackageRemap(object):
     def __init__(self):
-        self.remaps = {}
+        self.remaps = {}  # name (str): remap (UpgradeModuleRemap)
+
+    @classmethod
+    def __copy__(cls, obj):
+        newobj = cls()
+        newobj.remaps = dict((modname, copy.copy(modremap))
+                             for modname, modremap in obj.remaps.iteritems())
+        return newobj
 
     @classmethod
     def from_dict(cls, d):

--- a/vistrails/packages/matplotlib/identifiers.py
+++ b/vistrails/packages/matplotlib/identifiers.py
@@ -44,6 +44,6 @@ from __future__ import division
 
 identifier = 'org.vistrails.vistrails.matplotlib'
 name = 'matplotlib'
-version = '1.0.4'
+version = '1.0.5'
 old_identifiers = ['edu.utah.sci.vistrails.matplotlib',
                    'org.vistrails.matplotlib.new']

--- a/vistrails/packages/matplotlib/init.py
+++ b/vistrails/packages/matplotlib/init.py
@@ -186,6 +186,9 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
                                           'ylabel': None,
                                           'self': 'value'},
                        'src_port_remap': {'source': 'value'}})],
+                    'MplFigureCell':
+                    [(None, '1.0.5', 'MplFigureOutput',
+                      {'dst_port_remap': {'figure': 'value'}})],
                 }
 
     # '1.0.2' -> '1.0.3' changes 'self' output port to 'value'

--- a/vistrails/packages/matplotlib/init.py
+++ b/vistrails/packages/matplotlib/init.py
@@ -186,9 +186,6 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
                                           'ylabel': None,
                                           'self': 'value'},
                        'src_port_remap': {'source': 'value'}})],
-                    'MplFigureCell':
-                    [(None, '1.0.5', 'MplFigureOutput',
-                      {'dst_port_remap': {'figure': 'value'}})],
                 }
 
     # '1.0.2' -> '1.0.3' changes 'self' output port to 'value'
@@ -209,8 +206,18 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
         action = vistrails.core.db.action.create_action([('delete', conn)])
         action_list.append(action)
 
-    normal_actions = UpgradeWorkflowHandler.remap_module(controller, module_id, 
-                                                        pipeline, module_remap)
+    try:
+        from vistrails.packages.spreadsheet.init import upgrade_cell_to_output
+    except ImportError:
+        pass
+    else:
+        module_remap = upgrade_cell_to_output(
+                module_remap, module_id, pipeline,
+                'MplFigureCell', 'MplFigureOutput',
+                '1.0.5', 'figure')
+
+    normal_actions = UpgradeWorkflowHandler.remap_module(
+            controller, module_id, pipeline, module_remap)
     action_list.extend(normal_actions)
 
     more_ops = []

--- a/vistrails/packages/spreadsheet/identifiers.py
+++ b/vistrails/packages/spreadsheet/identifiers.py
@@ -38,5 +38,5 @@ from __future__ import division
 
 identifier = 'org.vistrails.vistrails.spreadsheet'
 name = 'VisTrails Spreadsheet'
-version = '0.9.3'
+version = '0.9.4'
 old_identifiers = ['edu.utah.sci.vistrails.spreadsheet']

--- a/vistrails/packages/spreadsheet/init.py
+++ b/vistrails/packages/spreadsheet/init.py
@@ -186,7 +186,11 @@ def upgrade_cell_to_output(module_remap, module_id, pipeline,
     if old_module_name != old_name:
         return module_remap
 
-    if set(old_module.connected_input_ports.keys()) != set([input_port_name]):
+    used_input_ports = set(old_module.connected_input_ports.keys())
+    for func in old_module.functions:
+        used_input_ports.add(func.name)
+
+    if used_input_ports != set([input_port_name]):
         return module_remap
 
     _old_remap = module_remap
@@ -196,6 +200,7 @@ def upgrade_cell_to_output(module_remap, module_id, pipeline,
                                module_name=old_name,
                                new_module=new_module)
     remap.add_remap('dst_port_remap', input_port_name, 'value')
+    remap.add_remap('function_remap', input_port_name, 'value')
     module_remap.add_module_remap(remap)
     return module_remap
 

--- a/vistrails/packages/spreadsheet/init.py
+++ b/vistrails/packages/spreadsheet/init.py
@@ -226,6 +226,10 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
             module_remap, module_id, pipeline,
             'RichTextCell', 'org.vistrails.vistrails.basic:RichTextOutput',
             '0.9.4', 'File')
+    module_remap = upgrade_cell_to_output(
+            module_remap, module_id, pipeline,
+            'ImageViewerCell', 'org.vistrails.vistrails.basic:ImageOutput',
+            '0.9.4', 'File')
 
     return UpgradeWorkflowHandler.remap_module(controller,
                                                module_id,

--- a/vistrails/packages/spreadsheet/init.py
+++ b/vistrails/packages/spreadsheet/init.py
@@ -165,8 +165,8 @@ def finalize():
 
 def upgrade_cell_to_output(module_remap, module_id, pipeline,
                            old_name, new_module,
-                           output_version, input_port_name,
-                           start_version=None):
+                           end_version, input_port_name,
+                           start_version=None, output_version=None):
     """This function upgrades a *Cell module to a *Output module.
 
     The upgrade only happens if the original module doesn't have any connection
@@ -196,7 +196,7 @@ def upgrade_cell_to_output(module_remap, module_id, pipeline,
     _old_remap = module_remap
     module_remap = copy.copy(module_remap)
     assert _old_remap.remaps is not module_remap.remaps
-    remap = UpgradeModuleRemap(start_version, output_version, output_version,
+    remap = UpgradeModuleRemap(start_version, end_version, output_version,
                                module_name=old_name,
                                new_module=new_module)
     remap.add_remap('dst_port_remap', input_port_name, 'value')

--- a/vistrails/packages/spreadsheet/init.py
+++ b/vistrails/packages/spreadsheet/init.py
@@ -180,6 +180,13 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
                         'self': 'value'},
                 }),
             ],
+            'RichTextCell': [
+                (None, '0.9.4',
+                 'org.vistrails.vistrails.basic:RichTextOutput', {
+                    'dst_port_remap': {
+                        'File': 'value'},
+                }),
+            ],
         }
 
     return UpgradeWorkflowHandler.remap_module(controller,

--- a/vistrails/packages/spreadsheet/init.py
+++ b/vistrails/packages/spreadsheet/init.py
@@ -165,7 +165,8 @@ def finalize():
 
 def upgrade_cell_to_output(module_remap, module_id, pipeline,
                            old_name, new_module,
-                           output_version, input_port_name):
+                           output_version, input_port_name,
+                           start_version=None):
     """This function upgrades a *Cell module to a *Output module.
 
     The upgrade only happens if the original module doesn't have any connection
@@ -191,7 +192,7 @@ def upgrade_cell_to_output(module_remap, module_id, pipeline,
     _old_remap = module_remap
     module_remap = copy.copy(module_remap)
     assert _old_remap.remaps is not module_remap.remaps
-    remap = UpgradeModuleRemap(None, output_version, output_version,
+    remap = UpgradeModuleRemap(start_version, output_version, output_version,
                                module_name=old_name,
                                new_module=new_module)
     remap.add_remap('dst_port_remap', input_port_name, 'value')

--- a/vistrails/packages/tabledata/identifiers.py
+++ b/vistrails/packages/tabledata/identifiers.py
@@ -2,4 +2,4 @@ from __future__ import division
 
 identifier = 'org.vistrails.vistrails.tabledata'
 name = 'tabledata'
-version = '0.1.5'
+version = '0.1.6'

--- a/vistrails/packages/tabledata/init.py
+++ b/vistrails/packages/tabledata/init.py
@@ -82,6 +82,12 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
                         None: add_keyname},
                 })
             ],
+            'TableCell': [
+                (None, '0.1.6', 'TableOutput', {
+                    'dst_port_remap': {
+                        'table': 'value'},
+                })
+            ],
         }
 
     return UpgradeWorkflowHandler.remap_module(controller,

--- a/vistrails/packages/tabledata/init.py
+++ b/vistrails/packages/tabledata/init.py
@@ -38,7 +38,7 @@ _modules = make_modules_dict(*_modules)
 
 def handle_module_upgrade_request(controller, module_id, pipeline):
     def add_keyname(fname, module):
-        new_function = controller.create_function(module, 
+        new_function = controller.create_function(module,
                                                   "key_name",
                                                   ["_key"])
         return [('add', new_function, 'module', module.id)]
@@ -82,13 +82,17 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
                         None: add_keyname},
                 })
             ],
-            'TableCell': [
-                (None, '0.1.6', 'TableOutput', {
-                    'dst_port_remap': {
-                        'table': 'value'},
-                })
-            ],
         }
+
+    try:
+        from vistrails.packages.spreadsheet.init import upgrade_cell_to_output
+    except ImportError:
+        pass
+    else:
+        module_remap = upgrade_cell_to_output(
+                module_remap, module_id, pipeline,
+                'TableCell', 'TableOutput',
+                '0.1.6', 'table')
 
     return UpgradeWorkflowHandler.remap_module(controller,
                                                module_id,

--- a/vistrails/packages/vtk/identifiers.py
+++ b/vistrails/packages/vtk/identifiers.py
@@ -39,4 +39,4 @@ from __future__ import division
 identifier = 'org.vistrails.vistrails.vtk'
 old_identifiers = ['edu.utah.sci.vistrails.vtk']
 name = 'VTK'
-version = '1.0.0'
+version = '1.0.1'

--- a/vistrails/packages/vtk/init.py
+++ b/vistrails/packages/vtk/init.py
@@ -661,7 +661,8 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
         module_remap = upgrade_cell_to_output(
                 _remap, module_id, pipeline,
                 'VTKCell', 'vtkRendererOutput',
-                '0.9.6', 'AddRenderer')
+                '1.0.1', 'AddRenderer',
+                start_version='1.0.0')
 
     return UpgradeWorkflowHandler.remap_module(controller, module_id, pipeline,
                                                module_remap)

--- a/vistrails/packages/vtk/init.py
+++ b/vistrails/packages/vtk/init.py
@@ -637,8 +637,10 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
         remap.add_remap('src_port_remap', 'self', 'Instance')
         _remap.add_module_remap(remap)
         remap = UpgradeModuleRemap(None, '1.0.0', '1.0.0',
-                                   module_name='VTKCell')
+                                   module_name='VTKCell',
+                                   new_module='vtkRendererOutput')
         remap.add_remap('src_port_remap', 'self', 'Instance')
+        remap.add_remap('dst_port_remap', 'AddRenderer', 'value')
         _remap.add_module_remap(remap)
         remap = UpgradeModuleRemap(None, '1.0.0', '1.0.0',
                                    module_name='VTKViewCell',

--- a/vistrails/packages/vtk/init.py
+++ b/vistrails/packages/vtk/init.py
@@ -630,6 +630,7 @@ def build_remap(module_name=None):
 
 def handle_module_upgrade_request(controller, module_id, pipeline):
     global _remap, _controller, _pipeline
+
     if _remap is None:
         _remap = UpgradePackageRemap()
         remap = UpgradeModuleRemap(None, '1.0.0', '1.0.0',
@@ -637,10 +638,8 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
         remap.add_remap('src_port_remap', 'self', 'Instance')
         _remap.add_module_remap(remap)
         remap = UpgradeModuleRemap(None, '1.0.0', '1.0.0',
-                                   module_name='VTKCell',
-                                   new_module='vtkRendererOutput')
+                                   module_name='VTKCell')
         remap.add_remap('src_port_remap', 'self', 'Instance')
-        remap.add_remap('dst_port_remap', 'AddRenderer', 'value')
         _remap.add_module_remap(remap)
         remap = UpgradeModuleRemap(None, '1.0.0', '1.0.0',
                                    module_name='VTKViewCell',
@@ -653,5 +652,16 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
     module_name = module_name_remap.get(module_name, module_name)
     if not _remap.has_module_remaps(module_name):
         build_remap(module_name)
+
+    try:
+        from vistrails.packages.spreadsheet.init import upgrade_cell_to_output
+    except ImportError:
+        module_remap = _remap
+    else:
+        module_remap = upgrade_cell_to_output(
+                _remap, module_id, pipeline,
+                'VTKCell', 'vtkRendererOutput',
+                '0.9.6', 'AddRenderer')
+
     return UpgradeWorkflowHandler.remap_module(controller, module_id, pipeline,
-                                              _remap)
+                                               module_remap)


### PR DESCRIPTION
It probably make sense to upgrade from `*Cell` modules to `*Output` modules.

* [x] matplotlib: `MplFigureCell`->`MplFigureOutput`
 * v2.1: 1.0.1, master: 1.0.4
 * 1.0.2: fixes to plots, 1.0.3: dont-use-modules-as-data, 1.0.4: added MplFigureToFile
 * will use 1.0.5
* [x] tabledata: `TableCell`->`TableOutput`
 * same version 0.1.5 because of backport (3d324de2)
 * should bump to 0.1.6 after backport and will use that
* [x] vtk: `VTKCell`->`vtkRendererOutput`
 * v2.1: 0.9.4, master: 0.9.5, #998: 1.0.0
 * 0.9.5: dont-use-modules-as-data
 * will use 0.9.6 or 1.0.0
 * [x] "save camera" feature?
* [x] spreadsheet: `RichTextCell`->`RichTextOutput`
* [x] `ImageViewerCell`->`ImageOutput` (#1013)
 * v2.1: 0.9.2, master: 0.9.3
 * 0.9.3: dont-use-modules-as-data
 * will use 0.9.4
* [x] keep `*Cell` module if some ports are connected/set