### PR TITLE
Fixes gmaps upgrade writing invalid workflow

### DIFF
--- a/vistrails/core/upgradeworkflow.py
+++ b/vistrails/core/upgradeworkflow.py
@@ -777,7 +777,7 @@ class UpgradeWorkflowHandler(object):
                 new_module_desc = ModuleDescriptor(package=new_module_t[0],
                                                    name=new_module_t[1],
                                                    namespace=new_module_t[2],
-                                                   version=new_pkg_version)
+                                                   package_version=new_pkg_version)
                 use_registry = False
 
                 # need to try more upgrades since this one isn't current
@@ -787,7 +787,7 @@ class UpgradeWorkflowHandler(object):
                                                         False)
                 old_version = new_pkg_version
                 next_module_remap = pkg_remap.get_module_upgrade(old_desc_str,
-                                                            old_version)
+                                                                 old_version)
                 old_module_t = new_module_t
             replace_module = UpgradeWorkflowHandler.replace_module
             actions = replace_module(controller, 

--- a/vistrails/packages/gmaps/init.py
+++ b/vistrails/packages/gmaps/init.py
@@ -109,7 +109,7 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
 
             new_vis_desc = ModuleDescriptor(package=identifier,
                                             name=vis_name,
-                                            version='0.3')
+                                            version='0.3.0')
             new_vis_module = \
                 controller.create_module_from_descriptor(new_vis_desc,
                                                          new_x, new_y)
@@ -148,13 +148,13 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
                                                   "allowLegacy",
                                                   ["True"])
         return [('add', new_function, 'module', module.id)]
-    remap.add_module_remap(UpgradeModuleRemap('0.1', '0.3', '0.3',
+    remap.add_module_remap(UpgradeModuleRemap('0.1.0', '0.3.0', '0.3.0',
                                               new_module="GMapCell",
                                               module_name="GMapCell",
                             dst_port_remap={'table': insert_vis("GMapSymbols",
                                             {None: add_legacy}),
                                             'colormapName': None}))
-    remap.add_module_remap(UpgradeModuleRemap('0.1', '0.3', '0.3',
+    remap.add_module_remap(UpgradeModuleRemap('0.1.0', '0.3.0', '0.3.0',
                                               new_module="GMapCell",
                                               module_name="GMapHeatmapCell",
                             dst_port_remap={'table': insert_vis("GMapHeatmap",
@@ -167,7 +167,7 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
                                             'opacity': None,
                                             'radius': None,
                                             }))
-    remap.add_module_remap(UpgradeModuleRemap('0.1', '0.3', '0.3',
+    remap.add_module_remap(UpgradeModuleRemap('0.1.0', '0.3.0', '0.3.0',
                                               new_module="GMapCell",
                                               module_name="GMapCircleCell",
                             dst_port_remap={'table': insert_vis("GMapCircles",
@@ -182,7 +182,7 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
                                             'fillColor': None,
                                             'fillOpacity': None,
                                             }))
-    remap.add_module_remap(UpgradeModuleRemap('0.1', '0.3', '0.3',
+    remap.add_module_remap(UpgradeModuleRemap('0.1.0', '0.3.0', '0.3.0',
                                               new_module="GMapCell",
                                               module_name="GMapSymbolCell",
                             dst_port_remap={'table': insert_vis("GMapSymbols",


### PR DESCRIPTION
Fixes #1021

Fixes the `ModuleDescriptor#package_version`/`version` typo, and puts the correct 0.x.0 versions in gmaps upgrades.