### PR TITLE
Store declined bundle installations in settings

### DIFF
--- a/vistrails/core/configuration.py
+++ b/vistrails/core/configuration.py
@@ -737,7 +737,8 @@ base_config = {
      ConfigField('spawned', False, bool, ConfigType.INTERNAL),
      ConfigField('rootDirectory', None, ConfigPath, ConfigType.INTERNAL),
      ConfigField('developerDebugger', False, bool, ConfigType.INTERNAL),
-     ConfigField('dontUnloadModules', False, bool, ConfigType.INTERNAL)],
+     ConfigField('dontUnloadModules', False, bool, ConfigType.INTERNAL),
+     ConfigField('promptInstallIPython', True, bool, ConfigType.INTERNAL)],
     "Jobs":
     [ConfigField('jobCheckInterval', 600, int),
      ConfigField('jobAutorun', False, bool),

--- a/vistrails/core/configuration.py
+++ b/vistrails/core/configuration.py
@@ -738,7 +738,7 @@ base_config = {
      ConfigField('rootDirectory', None, ConfigPath, ConfigType.INTERNAL),
      ConfigField('developerDebugger', False, bool, ConfigType.INTERNAL),
      ConfigField('dontUnloadModules', False, bool, ConfigType.INTERNAL),
-     ConfigField('promptInstallIPython', True, bool, ConfigType.INTERNAL)],
+     ConfigField('bundleDeclinedList', '', str, ConfigType.INTERNAL)],
     "Jobs":
     [ConfigField('jobCheckInterval', 600, int),
      ConfigField('jobAutorun', False, bool),

--- a/vistrails/gui/shell.py
+++ b/vistrails/gui/shell.py
@@ -67,7 +67,8 @@ def get_shell_dialog():
                 'linux-ubuntu': 'ipython-qtconsole',
                 'linux-debian': 'ipython-qtconsole'}
 
-        IPython = py_import('IPython.qt.console.rich_ipython_widget', deps)
+        IPython = py_import('IPython.qt.console.rich_ipython_widget', deps,
+                            setting="promptInstallIPython")
         RichIPythonWidget = \
                 IPython.qt.console.rich_ipython_widget.RichIPythonWidget
         py_import('IPython.qt.inprocess', deps)

--- a/vistrails/gui/shell.py
+++ b/vistrails/gui/shell.py
@@ -68,10 +68,10 @@ def get_shell_dialog():
                 'linux-debian': 'ipython-qtconsole'}
 
         IPython = py_import('IPython.qt.console.rich_ipython_widget', deps,
-                            setting="promptInstallIPython")
+                            True)
         RichIPythonWidget = \
                 IPython.qt.console.rich_ipython_widget.RichIPythonWidget
-        py_import('IPython.qt.inprocess', deps)
+        py_import('IPython.qt.inprocess', deps, True)
         QtInProcessKernelManager = \
                 IPython.qt.inprocess.QtInProcessKernelManager
     except ImportError:

--- a/vistrails/packages/URL/https_if_available.py
+++ b/vistrails/packages/URL/https_if_available.py
@@ -44,10 +44,12 @@ from vistrails.core import debug
 
 try:
     py_import('certifi', {
-            'pip': 'certifi'})
+                  'pip': 'certifi'},
+              True)
     py_import('backports.ssl_match_hostname', {
-            'pip': 'backports.ssl_match_hostname',
-            'linux-fedora': 'python-backports-ssl_match_hostname'})
+                  'pip': 'backports.ssl_match_hostname',
+                  'linux-fedora': 'python-backports-ssl_match_hostname'},
+              True)
 except ImportError:
     def build_opener(*args, **kwargs):
         insecure = kwargs.pop('insecure', False)

--- a/vistrails/packages/tabledata/read/read_excel.py
+++ b/vistrails/packages/tabledata/read/read_excel.py
@@ -49,10 +49,11 @@ from ..common import TableObject, Table
 def get_xlrd():
     try:
         return py_import('xlrd', {
-                'pip': 'xlrd',
-                'linux-debian': 'python-xlrd',
-                'linux-ubuntu': 'python-xlrd',
-                'linux-fedora': 'python-xlrd'})
+                             'pip': 'xlrd',
+                             'linux-debian': 'python-xlrd',
+                             'linux-ubuntu': 'python-xlrd',
+                             'linux-fedora': 'python-xlrd'},
+                         True)
     except ImportError: # pragma: no cover
         return None
 

--- a/vistrails/packages/tabledata/write/write_excel.py
+++ b/vistrails/packages/tabledata/write/write_excel.py
@@ -45,10 +45,11 @@ from ..common import Table
 def get_xlwt():
     try:
         return py_import('xlwt', {
-                'pip': 'xlwt',
-                'linux-debian': 'python-xlwt',
-                'linux-ubuntu': 'python-xlwt',
-                'linux-fedora': 'python-xlwt'})
+                             'pip': 'xlwt',
+                             'linux-debian': 'python-xlwt',
+                             'linux-ubuntu': 'python-xlwt',
+                             'linux-fedora': 'python-xlwt'},
+                         True)
     except ImportError: # pragma: no cover
         return None
 


### PR DESCRIPTION
Fixes #989

For imports in application code, we can use the VisTrails configuration; this is done for IPython.

For optional imports in packages, I would like to use the package's configuration, however there doesn't seem to be a way for the package to change its configuration. Needed for tabledata and URL packages.