### PR TITLE
Removes version layout animation

### DIFF
--- a/vistrails/gui/version_view.py
+++ b/vistrails/gui/version_view.py
@@ -786,9 +786,6 @@ class QVersionTreeScene(QInteractiveGraphicsScene):
         self.edges = {}     # (sourceVersion, targetVersion) -> edge gui object
         self.controller = None
         self.fullGraph = None
-        self.timer = QtCore.QBasicTimer()
-        self.animation_step = 1
-        self.num_animation_steps = 1
         self.emit_selection = True
         self.select_by_click = True
         self.connect(self, QtCore.SIGNAL("selectionChanged()"),
@@ -971,8 +968,7 @@ class QVersionTreeScene(QInteractiveGraphicsScene):
 
         # perform graph layout
         (tree, self.fullGraph, layout) = \
-            controller.refine_graph(float(self.animation_step)/
-                                    float(self.num_animation_steps))
+            controller.refine_graph(2.0)
 
         tClearRefine = time.clock() - tClearRefine
 
@@ -1070,32 +1066,13 @@ class QVersionTreeScene(QInteractiveGraphicsScene):
 
         # Update bounding rects and fit to all view
         tUpdate = time.clock()
-        if not self.controller.animate_layout:
-            self.updateSceneBoundingRect()
-        elif not self.timer.isActive():
-            self.timer.start(0, self)
+        self.updateSceneBoundingRect()
         tUpdate = time.clock() - tUpdate
 
         self.select_by_click = True
 
         t = time.clock() - t
         # print "time in msec to setupScene total: %f  refine %f  layout %f  create %f" % (t, tClearRefine, tCreate)
-
-    def timerEvent(self, event):
-        """ timerEvent(event: QTimerEvent) -> None
-        
-        Start up a timer for animating tree drawing events
-        """
-        if event.timerId() == self.timer.timerId():
-            self.animation_step += 1
-            if self.animation_step >= self.num_animation_steps:
-                self.animation_step = 1
-                self.timer.stop()
-                self.controller.animate_layout = False
-            self.setupScene(self.controller)
-            self.update()
-        else:
-            qt_super(QVersionTreeScene, self).timerEvent(event)
 
     def keyPressEvent(self, event):
         """ keyPressEvent(event: QKeyEvent) -> None

--- a/vistrails/gui/vistrail_controller.py
+++ b/vistrails/gui/vistrail_controller.py
@@ -160,8 +160,6 @@ class VistrailController(QtCore.QObject, BaseController):
         self.timer = None
         if self._auto_save:
             self.setup_timer()
-        
-        self._previous_graph_layout = None
 
         def width_f(text):
             return CurrentTheme.VERSION_FONT_METRIC.width(text)
@@ -630,7 +628,6 @@ class VistrailController(QtCore.QObject, BaseController):
 
     def recompute_terse_graph(self):
         BaseController.recompute_terse_graph(self)
-        self._previous_graph_layout = copy.deepcopy(self._current_graph_layout)
         self._current_graph_layout.layout_from(self.vistrail,
                                                self._current_terse_graph)
 


### PR DESCRIPTION
The version layout code supports animation, and the version view animates with a timer. But the number of animation steps is set to one (69cb4903).

This removes the timer and every mention of animation.

You can try out the animations by setting the number of steps in version_view.py:
```diff
diff --git a/vistrails/gui/version_view.py b/vistrails/gui/version_view.py
index 197bcb4..819cf97 100644
--- a/vistrails/gui/version_view.py
+++ b/vistrails/gui/version_view.py
@@ -790,3 +790,3 @@ class QVersionTreeScene#__init__()
         self.animation_step = 1
-        self.num_animation_steps = 1
+        self.num_animation_steps = 5
         self.emit_selection = True
```

My guess is that this can be slow for big version trees.