### PR TITLE
Fix backspace typo in VTK key handling code

### DIFF
--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -760,7 +760,7 @@ class QVTKWidget(QCellWidget):
         Convert Qt key code into key name
         
         """
-        handler = {QtCore.Qt.Key_Backspace:"BackSpace",
+        handler = {QtCore.Qt.Key_Backspace:"Backspace",
                    QtCore.Qt.Key_Tab:"Tab",
                    QtCore.Qt.Key_Backtab:"Tab",
                    QtCore.Qt.Key_Return:"Return",


### PR DESCRIPTION
Not sure how to check this but seems to be necessary in UV-CDAT.

UV-CDAT/VisTrails#34