### PR TITLE
Don't reset notes unless version really changes

### DIFF
--- a/vistrails/gui/version_prop.py
+++ b/vistrails/gui/version_prop.py
@@ -316,6 +316,8 @@ class QVersionNotes(QtGui.QTextEdit):
         Update the text to be the notes of the vistrail versionNumber
         
         """
+        if self.versionNumber == versionNumber:
+            return
         self.versionNumber = versionNumber
         if self.controller:
             if self.controller.vistrail.actionMap.has_key(versionNumber):


### PR DESCRIPTION
Fixes #1038 

Not completely sure this doesn't mess up something else, but I don't see anything.

Remark: I didn't change the behavior for tags, but it's easier to press Enter there, and there is visual feedback for when the tagging actually happen (it shows up on the version node).