### PR TITLE
Fixes Q/E support

### DIFF
--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -679,10 +679,10 @@ class QVTKWidget(QCellWidget):
         if not keysym:
             keysym = self.qt_key_to_key_sym(e.key())
 
-        # Ignore 'q' or 'e' or Ctrl-anykey
+        # Ignore Ctrl-anykey
         ctrl = (e.modifiers()&QtCore.Qt.ControlModifier)
         shift = (e.modifiers()&QtCore.Qt.ShiftModifier)
-        if (keysym in ['q','e'] or ctrl):
+        if ctrl:
             e.ignore()
             return
         


### PR DESCRIPTION
UV-CDAT/VisTrails#36

I'm not sure why this is here; I assume these keys might have been handled by the VTK renderwindow in ways that were problematic initially (this dates back to the initial addition of VTKCell in 2007 by @hvo)