### PR TITLE
Remove generated pkg ids (get_vistrails_default_pkg_prefix())

### DIFF
--- a/vistrails/core/inspector.py
+++ b/vistrails/core/inspector.py
@@ -38,7 +38,6 @@
 from __future__ import division
 
 from vistrails.core.modules.module_registry import get_module_registry
-from vistrails.core.system import get_vistrails_default_pkg_prefix
 ################################################################################
 
 class PipelineInspector(object):
@@ -159,8 +158,7 @@ class PipelineInspector(object):
             if root_id is None:
                 root_id = []
             # Sometimes we run without the spreadsheet!
-            spreadsheet_pkg = \
-                '%s.spreadsheet' % get_vistrails_default_pkg_prefix()
+            spreadsheet_pkg = 'org.vistrails.vistrails.spreadsheet'
             if registry.has_module(spreadsheet_pkg, 'SpreadsheetCell'):
                 # First pass to check cells types
                 cellType = \

--- a/vistrails/core/inspector.py
+++ b/vistrails/core/inspector.py
@@ -37,7 +37,6 @@
 """Helper classes for inspecting vistrails/pipelines at runtime"""
 from __future__ import division
 
-from vistrails.core.vistrail.pipeline import Pipeline
 from vistrails.core.modules.module_registry import get_module_registry
 from vistrails.core.system import get_vistrails_default_pkg_prefix
 ################################################################################

--- a/vistrails/core/modules/utils.py
+++ b/vistrails/core/modules/utils.py
@@ -35,7 +35,7 @@
 ###############################################################################
 from __future__ import division
 
-from vistrails.core.system import get_vistrails_default_pkg_prefix, \
+from vistrails.core.system import _defaultPkgPrefix, \
     get_vistrails_basic_pkg_id, get_module_registry
 
 def load_cls(cls_item, prefix=None):
@@ -93,7 +93,7 @@ def parse_descriptor_string(d_string, cur_package=None):
         if '.' in parts[0]:
             package = parts[0]
         else:
-            package = '%s.%s' % (get_vistrails_default_pkg_prefix(), parts[0])
+            package = '%s.%s' % (_defaultPkgPrefix, parts[0])
     else:
         qual_name = d_string
         if cur_package is None:

--- a/vistrails/core/modules/utils.py
+++ b/vistrails/core/modules/utils.py
@@ -35,7 +35,6 @@
 ###############################################################################
 from __future__ import division
 
-import vistrails.core
 from vistrails.core.system import get_vistrails_default_pkg_prefix, \
     get_vistrails_basic_pkg_id, get_module_registry
 

--- a/vistrails/core/system/__init__.py
+++ b/vistrails/core/system/__init__.py
@@ -37,18 +37,15 @@ from __future__ import division, with_statement
 
 import datetime
 import functools
-import getpass
 import locale
 import os
 import platform
-import socket
-import subprocess
 import sys
 import time
 import urllib2
 
 from vistrails.core import debug
-from vistrails.core.utils import unimplemented, VistrailsInternalError, Chdir
+from vistrails.core.utils import unimplemented, Chdir
 
 
 ###############################################################################

--- a/vistrails/core/system/__init__.py
+++ b/vistrails/core/system/__init__.py
@@ -43,9 +43,10 @@ import platform
 import sys
 import time
 import urllib2
+import warnings
 
 from vistrails.core import debug
-from vistrails.core.utils import unimplemented, Chdir
+from vistrails.core.utils import unimplemented, VistrailsDeprecation, Chdir
 
 
 ###############################################################################
@@ -138,10 +139,17 @@ __defaultFileType = '.vt'
 __defaultPkgPrefix = 'org.vistrails.vistrails'
 
 def get_vistrails_default_pkg_prefix():
+    """Gets the namespace under which identifiers of builtin packages live.
+
+    You should *not* use this, it is only useful intended to expand short names
+    of builtin packages.
+    """
+    warnings.warn("get_vistrails_default_pkg_prefix() is deprecated",
+                  category=VistrailsDeprecation)
     return __defaultPkgPrefix
 
 def get_vistrails_basic_pkg_id():
-    return "%s.basic" % get_vistrails_default_pkg_prefix()
+    return "%s.basic" % __defaultPkgPrefix
 
 def get_vistrails_directory(config_key, conf=None):
     if conf is None:

--- a/vistrails/core/system/__init__.py
+++ b/vistrails/core/system/__init__.py
@@ -136,20 +136,20 @@ __examplesDir = __fileDir
 
 __defaultFileType = '.vt'
 
-__defaultPkgPrefix = 'org.vistrails.vistrails'
+_defaultPkgPrefix = 'org.vistrails.vistrails'
 
 def get_vistrails_default_pkg_prefix():
     """Gets the namespace under which identifiers of builtin packages live.
 
     You should *not* use this, it is only useful intended to expand short names
-    of builtin packages.
+    of builtin packages in parse_descriptor_string.
     """
     warnings.warn("get_vistrails_default_pkg_prefix() is deprecated",
                   category=VistrailsDeprecation)
-    return __defaultPkgPrefix
+    return _defaultPkgPrefix
 
 def get_vistrails_basic_pkg_id():
-    return "%s.basic" % __defaultPkgPrefix
+    return "%s.basic" % _defaultPkgPrefix
 
 def get_vistrails_directory(config_key, conf=None):
     if conf is None:

--- a/vistrails/core/utils/__init__.py
+++ b/vistrails/core/utils/__init__.py
@@ -39,7 +39,6 @@ used all over VisTrails.
 """
 from __future__ import division, with_statement
 
-import vistrails.core.debug
 from vistrails.core.utils.enum import enum
 from vistrails.core.utils.timemethod import time_method, time_call
 from vistrails.core.utils.tracemethod import trace_method, bump_trace, report_stack, \

--- a/vistrails/core/vistrail/pipeline.py
+++ b/vistrails/core/vistrail/pipeline.py
@@ -44,8 +44,7 @@ from vistrails.core.data_structures.graph import Graph
 from vistrails.core import debug
 from vistrails.core.modules.module_registry import get_module_registry, \
     ModuleRegistryException, MissingModuleVersion, MissingPackage, PortMismatch
-from vistrails.core.system import get_vistrails_default_pkg_prefix, \
-    get_vistrails_basic_pkg_id
+from vistrails.core.system import get_vistrails_basic_pkg_id
 from vistrails.core.utils import VistrailsInternalError
 from vistrails.core.vistrail.group import Group
 from vistrails.core.vistrail.module_control_param import ModuleControlParam
@@ -1325,7 +1324,7 @@ class TestPipeline(unittest.TestCase):
             m = Module()
             m.id = id_scope.getNewId(Module.vtType)
             m.name = 'PythonCalc'
-            m.package = '%s.pythoncalc' % get_vistrails_default_pkg_prefix()
+            m.package = 'org.vistrails.vistrails.pythoncalc'
             m.functions.append(f1())
             m.control_parameters.append(cp1())
             return m
@@ -1344,7 +1343,7 @@ class TestPipeline(unittest.TestCase):
             m = Module()
             m.id = id_scope.getNewId(Module.vtType)
             m.name = 'PythonCalc'
-            m.package = '%s.pythoncalc' % get_vistrails_default_pkg_prefix()
+            m.package = 'org.vistrails.vistrails.pythoncalc'
             m.functions.append(f1())
             return m
         m1 = module1(p)
@@ -1554,7 +1553,7 @@ class TestPipeline(unittest.TestCase):
     def test_module_signature(self):
         """Tests signatures for modules with similar (but not equal)
         parameter specs."""
-        pycalc_pkg = '%s.pythoncalc' % get_vistrails_default_pkg_prefix()
+        pycalc_pkg = 'org.vistrails.vistrails.pythoncalc'
         p1 = Pipeline()
         p1_functions = [ModuleFunction(name='value1',
                                        parameters=[ModuleParam(type='Float',
@@ -1603,8 +1602,7 @@ class TestPipeline(unittest.TestCase):
                                                                )],
                                        )]
         p1.add_module(Module(name='CacheBug', 
-                            package='%s.console_mode_test' % \
-                             get_vistrails_default_pkg_prefix(),
+                            package='org.vistrails.vistrails.console_mode_test',
                             id=3,
                             functions=p1_functions))
 
@@ -1626,8 +1624,7 @@ class TestPipeline(unittest.TestCase):
                                                                )],
                                        )]
         p1.add_module(Module(name='CacheBug', 
-                            package='%s.console_mode_test' % \
-                             get_vistrails_default_pkg_prefix(),
+                            package='org.vistrails.vistrails.console_mode_test',
                             id=3,
                             functions=p1_functions))
         str(p1)

--- a/vistrails/core/vistrail/pipeline.py
+++ b/vistrails/core/vistrail/pipeline.py
@@ -42,29 +42,19 @@ from vistrails.core.configuration import get_vistrails_configuration
 from vistrails.core.data_structures.bijectivedict import Bidict
 from vistrails.core.data_structures.graph import Graph
 from vistrails.core import debug
-from vistrails.core.modules.module_descriptor import ModuleDescriptor
 from vistrails.core.modules.module_registry import get_module_registry, \
     ModuleRegistryException, MissingModuleVersion, MissingPackage, PortMismatch
 from vistrails.core.system import get_vistrails_default_pkg_prefix, \
     get_vistrails_basic_pkg_id
 from vistrails.core.utils import VistrailsInternalError
-from vistrails.core.utils import expression, append_to_dict_of_lists
-from vistrails.core.utils.uxml import named_elements
-from vistrails.core.vistrail.abstraction import Abstraction
-from vistrails.core.vistrail.connection import Connection
 from vistrails.core.vistrail.group import Group
-from vistrails.core.vistrail.module import Module
 from vistrails.core.vistrail.module_control_param import ModuleControlParam
-from vistrails.core.vistrail.module_function import ModuleFunction
-from vistrails.core.vistrail.module_param import ModuleParam
 from vistrails.core.vistrail.plugin_data import PluginData
-from vistrails.core.vistrail.port import Port, PortEndPoint
 from vistrails.core.vistrail.port_spec import PortSpec
 from vistrails.db.domain import DBWorkflow
 import vistrails.core.vistrail.action
-from vistrails.core.utils import profile, InvalidPipeline
+from vistrails.core.utils import InvalidPipeline
 
-from xml.dom.minidom import getDOMImplementation, parseString
 import copy
 
 import unittest

--- a/vistrails/db/services/opm.py
+++ b/vistrails/db/services/opm.py
@@ -38,8 +38,7 @@ from __future__ import division
 from ast import literal_eval
 import copy
 import sys
-from vistrails.core.system import get_vistrails_default_pkg_prefix, \
-    get_vistrails_basic_pkg_id
+from vistrails.core.system import get_vistrails_basic_pkg_id
 import vistrails.db.services.io
 from vistrails.db.domain import DBOpmProcess, DBOpmArtifact, DBOpmUsed, \
     DBOpmWasGeneratedBy, DBOpmProcessIdCause, DBOpmProcessIdEffect, \
@@ -415,7 +414,7 @@ def create_opm(workflow, version, log, reg):
             out_downstream_artifacts = {}
 
 
-        ctrl_flow_pkg = '%s.control_flow' % get_vistrails_default_pkg_prefix()
+        ctrl_flow_pkg = 'org.vistrails.vistrails.control_flow'
         basic_pkg = get_vistrails_basic_pkg_id()
         all_special_ports = {'%s:Map' % ctrl_flow_pkg:
                                  [{'InputPort': False, 

--- a/vistrails/gui/paramexplore/pe_tab.py
+++ b/vistrails/gui/paramexplore/pe_tab.py
@@ -269,7 +269,7 @@ class QParameterExplorationTab(QDockContainer, QToolWindowInterface):
         """
         registry = get_module_registry()
         actions = self.peWidget.table.collectParameterActions()
-        spreadsheet_pkg = '%s.spreadsheet' % get_vistrails_default_pkg_prefix()
+        spreadsheet_pkg = 'org.vistrails.vistrails.spreadsheet'
         # Set the annotation to persist the parameter exploration
         # TODO: For now, we just replace the existing exploration - Later we should append them.
         xmlString = "<paramexps>\n" + self.getParameterExploration() + "\n</paramexps>"

--- a/vistrails/gui/vistrail_controller.py
+++ b/vistrails/gui/vistrail_controller.py
@@ -1198,8 +1198,7 @@ class VistrailController(QtCore.QObject, BaseController):
         
         """
         reg = get_module_registry()
-        spreadsheet_pkg = '%s.spreadsheet' % \
-                vistrails.core.system.get_vistrails_default_pkg_prefix()
+        spreadsheet_pkg = 'org.vistrails.vistrails.spreadsheet'
         use_spreadsheet = reg.has_module(spreadsheet_pkg, 'CellLocation') and\
                           reg.has_module(spreadsheet_pkg, 'SheetReference')
 

--- a/vistrails/packages/vtk/init.py
+++ b/vistrails/packages/vtk/init.py
@@ -67,8 +67,7 @@ from . import hasher
 _modules = tf_modules + inspector_modules + offscreen_modules
 
 registry = get_module_registry()
-if registry.has_module('%s.spreadsheet' % get_vistrails_default_pkg_prefix(),
-                       'SpreadsheetCell'):
+if registry.has_module('org.vistrails.vistrails.spreadsheet', 'SpreadsheetCell'):
     # load these only if spreadsheet is enabled
     from .vtkcell import _modules as cell_modules
     from .vtkhandler import _modules as handler_modules
@@ -160,8 +159,8 @@ class vtkRendererOutput(OutputModule):
                     ('interactorStyle', 'vtkInteractorStyle'),
                     ('picker', 'vtkAbstractPicker')]
     _output_modes = [vtkRendererToFile, vtkRendererToIPythonMode]
-    if registry.has_module('%s.spreadsheet' % get_vistrails_default_pkg_prefix(),
-                       'SpreadsheetCell'):
+    if registry.has_module('org.vistrails.vistrails.spreadsheet',
+                           'SpreadsheetCell'):
         from .vtkcell import vtkRendererToSpreadsheet
         _output_modes.append(vtkRendererToSpreadsheet)
 


### PR DESCRIPTION
The whole point of identifiers is to be a unique immutable string identifying a module. Dynamically computing it defeats the purpose.

They should not change and code should rely on that fact. VisTrails has already been made tolerant to changes in identifiers via the old_identifiers and can_handle_identifier() mechanisms.