### PR TITLE
Removes vtkRendererOutput's spreadsheet ports

### DIFF
--- a/vistrails/packages/vtk/init.py
+++ b/vistrails/packages/vtk/init.py
@@ -156,16 +156,14 @@ class vtkRendererToIPythonMode(IPythonMode):
 class vtkRendererOutput(OutputModule):
     _settings = ModuleSettings(configure_widget="vistrails.gui.modules."
                        "output_configuration:OutputModuleConfigurationWidget")
-    _input_ports = [('value', 'vtkRenderer', {'depth':1})]
+    _input_ports = [('value', 'vtkRenderer', {'depth':1}),
+                    ('interactorStyle', 'vtkInteractorStyle'),
+                    ('picker', 'vtkAbstractPicker')]
     _output_modes = [vtkRendererToFile, vtkRendererToIPythonMode]
     if registry.has_module('%s.spreadsheet' % get_vistrails_default_pkg_prefix(),
                        'SpreadsheetCell'):
-        _input_ports.extend([('interactionHandler', 'vtkInteractionHandler',
-                              {'depth':1}),
-                             ('interactorStyle', 'vtkInteractorStyle'),
-                             ('picker', 'vtkAbstractPicker')])
         from .vtkcell import vtkRendererToSpreadsheet
-        _output_modes.insert(0,vtkRendererToSpreadsheet)
+        _output_modes.append(vtkRendererToSpreadsheet)
 
 _modules.append(vtkRendererOutput)
 

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -62,10 +62,9 @@ class vtkRendererToSpreadsheet(SpreadsheetMode):
         for ren, m in d.iteritems():
             ren.module_id = m.moduleInfo['moduleId']
         renderers = output_module.force_get_input('value') or []
-        handlers = output_module.force_get_input('interactionHandler') or []
         style = output_module.force_get_input('interactorStyle')
         picker = output_module.force_get_input('picker')
-        input_ports = (renderers, None, handlers, style, picker)
+        input_ports = (renderers, None, [], style, picker)
         self.cellWidget = self.display_and_wait(output_module, configuration,
                                                 QVTKWidget, input_ports)
 


### PR DESCRIPTION
Follows up on #1042

No module should have variable ports, this is especially true for output modules (whose whole point is to be usable no matter the available output modes).

It looks like vtkInteractorStyle and vtkAbstractPicker are available even if the spreadsheet isn't enabled, @rexissimus can you confirm?

vtkInteractionHandler is NOT available if the spreadsheet is not enabled, so I removed it.