### PR TITLE
Improve upgrades system, add tests

### DIFF
--- a/vistrails/tests/resources/upgrades_testcases/__init__.py
+++ b/vistrails/tests/resources/upgrades_testcases/__init__.py
@@ -1,0 +1,3 @@
+identifier = 'org.vistrails.test.upgrades_testcases'
+name ='upgrades_testcases'
+version = '0.5'

--- a/vistrails/tests/resources/upgrades_testcases/init.py
+++ b/vistrails/tests/resources/upgrades_testcases/init.py
@@ -1,0 +1,56 @@
+from vistrails.core.modules.vistrails_module import Module
+from vistrails.core.upgradeworkflow import UpgradeModuleRemap
+
+
+_upgrades = {}
+_modules = []
+
+
+class Test1(Module):
+    _input_ports = [('port2', 'basic:String')]
+
+
+_upgrades['Test1'] = [UpgradeModuleRemap('0.2', '0.4', '0.4', None,
+                                         function_remap={'port': 'port2'},
+                                         src_port_remap={'port': 'port2'})]
+_modules.append(Test1)
+
+
+class Test2(Module):
+    _input_ports = [('port3', 'basic:String')]
+
+_upgrades['Test2'] = [UpgradeModuleRemap('0.1', '0.3', '0.3', None,
+                                         function_remap={'port': 'port2'},
+                                         src_port_remap={'port': 'port2'}),
+                      UpgradeModuleRemap('0.3', '0.4', '0.5', None,
+                                         function_remap={'port2': 'port3'},
+                                         src_port_remap={'port2': 'port3'}),
+                      UpgradeModuleRemap('0.4', '0.5', '0.5', 'Test2n')]
+_modules.append(Test2)
+
+
+class Test3(Module):
+    _input_ports = [('port4', 'basic:String')]
+
+_upgrades['Test3'] = [UpgradeModuleRemap('0.1', '0.3', '0.3', None,
+                                         function_remap={'port': 'port2'},
+                                         src_port_remap={'port': 'port2'}),
+                      UpgradeModuleRemap('0.3', '0.4', '0.5', None,
+                                         function_remap={'port2': 'port3'},
+                                         src_port_remap={'port2': 'port3'}),
+                      UpgradeModuleRemap('0.2', '0.3', '0.5', None,
+                                         function_remap={'port': 'port4'},
+                                         src_port_remap={'port': 'port4'})]
+_modules.append(Test3)
+
+
+class Test4(Module):
+    _input_ports = [('port3', 'basic:String')]
+
+_upgrades['Test4'] = [UpgradeModuleRemap('0.1', '0.2', '0.2', None,
+                                         function_remap={'port': 'port2'},
+                                         src_port_remap={'port': 'port2'}),
+                      UpgradeModuleRemap('0.3', '0.4', '0.4', None,
+                                         function_remap={'port2': 'port3'},
+                                         src_port_remap={'port2': 'port3'})]
+_modules.append(Test4)

--- a/vistrails/tests/utils.py
+++ b/vistrails/tests/utils.py
@@ -67,67 +67,10 @@ def enable_package(identifier):
             pm.late_enable_package(pkg.codepath)
 
 
-def execute(modules, connections=[], add_port_specs=[],
-            enable_pkg=True, full_results=False):
-    """Build a pipeline and execute it.
-
-    This is useful to simply build a pipeline in a test case, and run it. When
-    doing that, intercept_result() can be used to check the results of each
-    module.
-
-    modules is a list of module tuples describing the modules to be created,
-    with the following format:
-        [('ModuleName', 'package.identifier', [
-            # Functions
-            ('port_name', [
-                # Function parameters
-                ('Signature', 'value-as-string'),
-            ]),
-        ])]
-
-    connections is a list of tuples describing the connections to make, with
-    the following format:
-        [
-            (source_module_index, 'source_port_name',
-             dest_module_index, 'dest_module_name'),
-         ]
-
-    add_port_specs is a list of specs to add to modules, with the following
-    format:
-        [
-            (mod_id, 'input'/'output', 'portname',
-             '(port_sig)'),
-        ]
-    It is useful to test modules that can have custom ports through a
-    configuration widget.
-
-    The function returns the 'errors' dict it gets from the interpreter, so you
-    should use a construct like self.assertFalse(execute(...)) if the execution
-    is not supposed to fail.
-
-
-    For example, this creates (and runs) an Integer module with its value set
-    to 44, connected to a PythonCalc module, connected to a StandardOutput:
-
-    self.assertFalse(execute([
-            ('Float', 'org.vistrails.vistrails.basic', [
-                ('value', [('Float', '44.0')]),
-            ]),
-            ('PythonCalc', 'org.vistrails.vistrails.pythoncalc', [
-                ('value2', [('Float', '2.0')]),
-                ('op', [('String', '-')]),
-            ]),
-            ('StandardOutput', 'org.vistrails.vistrails.basic', []),
-        ],
-        [
-            (0, 'value', 1, 'value1'),
-            (1, 'value', 2, 'value'),
-        ]))
-    """
-    from vistrails.core.db.locator import XMLFileLocator
+def build_pipeline(modules, connections=[], add_port_specs=[],
+                   enable_pkg=True):
     from vistrails.core.modules.module_registry import MissingPackage
     from vistrails.core.packagemanager import get_package_manager
-    from vistrails.core.utils import DummyView
     from vistrails.core.vistrail.connection import Connection
     from vistrails.core.vistrail.module import Module
     from vistrails.core.vistrail.module_function import ModuleFunction
@@ -135,7 +78,6 @@ def execute(modules, connections=[], add_port_specs=[],
     from vistrails.core.vistrail.pipeline import Pipeline
     from vistrails.core.vistrail.port import Port
     from vistrails.core.vistrail.port_spec import PortSpec
-    from vistrails.core.interpreter.noncached import Interpreter
 
     pm = get_package_manager()
 
@@ -207,6 +149,70 @@ def execute(modules, connections=[], add_port_specs=[],
                          name=dport,
                          signature=d_sig),
                 ]))
+
+
+def execute(modules, connections=[], add_port_specs=[],
+            enable_pkg=True, full_results=False):
+    """Build a pipeline and execute it.
+
+    This is useful to simply build a pipeline in a test case, and run it. When
+    doing that, intercept_result() can be used to check the results of each
+    module.
+
+    modules is a list of module tuples describing the modules to be created,
+    with the following format:
+        [('ModuleName', 'package.identifier', [
+            # Functions
+            ('port_name', [
+                # Function parameters
+                ('Signature', 'value-as-string'),
+            ]),
+        ])]
+
+    connections is a list of tuples describing the connections to make, with
+    the following format:
+        [
+            (source_module_index, 'source_port_name',
+             dest_module_index, 'dest_module_name'),
+         ]
+
+    add_port_specs is a list of specs to add to modules, with the following
+    format:
+        [
+            (mod_id, 'input'/'output', 'portname',
+             '(port_sig)'),
+        ]
+    It is useful to test modules that can have custom ports through a
+    configuration widget.
+
+    The function returns the 'errors' dict it gets from the interpreter, so you
+    should use a construct like self.assertFalse(execute(...)) if the execution
+    is not supposed to fail.
+
+
+    For example, this creates (and runs) an Integer module with its value set
+    to 44, connected to a PythonCalc module, connected to a StandardOutput:
+
+    self.assertFalse(execute([
+            ('Float', 'org.vistrails.vistrails.basic', [
+                ('value', [('Float', '44.0')]),
+            ]),
+            ('PythonCalc', 'org.vistrails.vistrails.pythoncalc', [
+                ('value2', [('Float', '2.0')]),
+                ('op', [('String', '-')]),
+            ]),
+            ('StandardOutput', 'org.vistrails.vistrails.basic', []),
+        ],
+        [
+            (0, 'value', 1, 'value1'),
+            (1, 'value', 2, 'value'),
+        ]))
+    """
+    from vistrails.core.db.locator import XMLFileLocator
+    from vistrails.core.interpreter.noncached import Interpreter
+    from vistrails.core.utils import DummyView
+
+    pipeline = build_pipeline(modules, connections, add_port_specs, enable_pkg)
 
     interpreter = Interpreter.get()
     result = interpreter.execute(


### PR DESCRIPTION
This branch has more contrived tests for the upgrades system. Most don't pass.

* [ ] test_upgrade1: This upgrades from version 0.2 to 0.4. There is no explicit upgrade to 0.4 to 0.5, but an automatic upgrade would succeed; however it is not attempted.
* [X] test_upgrade2: This chains two upgrades, with no ambiguity.
* [ ] test_upgrade3: Here there are multiple possible upgrade from 0.2: either to 0.3 (then 0.5), or directly to 0.5. The upgrade to 0.3 is preferred, this is wrong.
* [ ] test_upgrade4: Here several automatic upgrade would be needed. Module is 0.0, would need to get to 0.1 to upgrade to 0.2, then auto to 0.3 to upgrade to 0.4, then auto to 0.5.

I'm not entirely sure what can be done and what we want to support (specially in terms of automatic upgrades). Discussion is probably needed here.

This doesn't yet cover the problem @rexissimus ran into on VTK functions, #1047. It might be a different issue fixable separately.

#1017 can probably fixed without handling all of this, although the upgrades won't be as robust.