### PR TITLE
Fix version prop

### DIFF
--- a/vistrails/gui/version_prop.py
+++ b/vistrails/gui/version_prop.py
@@ -58,7 +58,7 @@ from vistrails.core.vistrail.controller import custom_color_key, \
 from vistrails.gui.theme import CurrentTheme
 from vistrails.gui.vistrails_palette import QVistrailsPaletteInterface
 
-################################################################################
+###############################################################################
 
 class ColorChooserButton(QtGui.QPushButton):
     color_selected = QtCore.pyqtSignal(object)
@@ -94,7 +94,7 @@ class ColorChooserButton(QtGui.QPushButton):
             if color.isValid():
                 self.setColor(color, silent=False)
 
-################################################################################
+###############################################################################
 
 class QVersionProp(QtGui.QWidget, QVistrailsPaletteInterface):
     """
@@ -365,8 +365,8 @@ class QVersionNotes(QtGui.QTextEdit):
             cursor = QtGui.QTextCursor(doc)
             cursor.deleteChar()
 
+###############################################################################
 
-################################################################################
 class QVersionPropOverlay(QtGui.QFrame):
     """
     QVersionPropOverlay is a transparent widget that sits on top of the version
@@ -564,7 +564,8 @@ class QVersionPropOverlay(QtGui.QFrame):
                 return False
         return QtGui.QFrame.event(self, e)
 
-################################################################################
+###############################################################################
+
 class QExpandButton(QtGui.QLabel):
     """
     A transparent button type with a + draw in 
@@ -625,7 +626,8 @@ class QExpandButton(QtGui.QLabel):
         painter.end()
         self.setPicture(self.picture)
 
-################################################################################
+###############################################################################
+
 class QNotesDialog(QtGui.QDialog):
     """
     A small non-modal dialog with text entry to modify and view notes
@@ -719,7 +721,7 @@ class QNotesDialog(QtGui.QDialog):
         """
         return QtCore.QSize(250,200)
         
-################################################################################
+###############################################################################
 
 class QVersionThumbs(QtGui.QWidget):
     def __init__(self, parent=None):
@@ -767,7 +769,8 @@ class QVersionThumbs(QtGui.QWidget):
         self.thumbs.setPixmap(QtGui.QPixmap())
         self.thumbs.setFrameShape(QtGui.QFrame.NoFrame)
 
-################################################################################
+###############################################################################
+
 class QVersionMashups(QtGui.QWidget):
     def __init__(self, parent=None):
         QtGui.QWidget.__init__(self, parent)

--- a/vistrails/gui/vistrail_controller.py
+++ b/vistrails/gui/vistrail_controller.py
@@ -353,7 +353,7 @@ class VistrailController(QtCore.QObject, BaseController):
             self.vistrail.set_notes(notes_version, None)
 
         # Add notes
-        if self.vistrail.set_notes(self.current_version, str(notes)):
+        if self.vistrail.set_notes(self.current_base_version, str(notes)):
             self.set_changed(True)
             self.emit(QtCore.SIGNAL('notesChanged()'))
 
@@ -753,9 +753,9 @@ class VistrailController(QtCore.QObject, BaseController):
         self.vistrail.set_tag(tag_version, None)
 
         if self.vistrail.hasTag(self.current_version):
-            self.vistrail.changeTag(tag, self.current_version)
+            self.vistrail.changeTag(tag, self.current_base_version)
         else:
-            self.vistrail.addTag(tag, self.current_version)
+            self.vistrail.addTag(tag, self.current_base_version)
 
         self.set_changed(True)
         self.recompute_terse_graph()


### PR DESCRIPTION
Closes #1050

This should fix the GUI issues introduced by #1046. Vistrail gets a new method `search_upgrade_versions()` which allows searching the whole upgrade chain until the supplied function returns a value. That function is used in version_prop.py and vistrail_controller.py to find notes and tags.

If changing notes or tags, it will be moved from its current location in the upgrade chain to the original version node (the one that's not an upgrade).

Weird things shouldn't happen, even if you have several notes/tags in the same chain, although you may have to disable "don't show upgrades" to be able to select these nodes.