### PR TITLE
relative_to port on File module

### DIFF
--- a/scripts/dist/common/prepare_release.py
+++ b/scripts/dist/common/prepare_release.py
@@ -82,41 +82,45 @@ if __name__ == '__main__':
     # Get info from CHANGELOG
     # Assumes 3:rd line and fixed format
     line = lines[2].split()
-    VERSION = line[2][1:] # Drop "v" prefix
-    HASH = line[4]
-    BRANCH = line[6]
- 
+    version = line[2][1:] # Drop "v" prefix
+    hash = line[4]
+    branch = line[6]
+
     try:
-        hash = subprocess.check_output(['git', 'rev-parse', '--verify', 'HEAD',
-                                       '--short=12']).strip()
-        if hash != HASH:
+        read_hash = subprocess.check_output(['git', 'rev-parse', '--verify', 'HEAD',
+                                             '--short=12']).strip()
+        if read_hash != hash:
             # update hash in changelog
-            update_value('CHANGELOG', r'Release Name: v%s build ' % VERSION, hash)
-            HASH = hash
+            update_value('CHANGELOG', r'Release Name: v%s build ' % version, read_hash)
+            hash = read_hash
     except subprocess.CalledProcessError: # Not a git repository
         pass
 
     for fname, pre in VERSION_FILES:
-       update_value(fname, pre, VERSION)
+       update_value(fname, pre, version)
 
     for fname, pre in HASH_FILES:
-       update_value(fname, pre, HASH)
+       update_value(fname, pre, hash)
 
     for fname, pre in BRANCH_FILES:
         # Cut off 'v' in versioned branches
-        branch = BRANCH[1:] if BRANCH[0] == 'v' else BRANCH
-        update_value(fname, pre, branch)
+        file_branch = branch[1:] if branch[0] == 'v' else branch
+        update_value(fname, pre, file_branch)
 
     for fname, pre in BRANCH_FILES_V:
-        update_value(fname, pre, BRANCH)
+        update_value(fname, pre, branch)
 
     for fname, pre in BRANCH_URLS:
         # master version of usersguide url is 'dev'
-        branch = 'dev' if BRANCH in ['dev', 'master'] else BRANCH
-        update_value(fname, pre, branch)
+        url_branch = 'dev' if branch in ['dev', 'master'] else branch
+        update_value(fname, pre, url_branch)
 
     # Update splash using inkscape
     try:
-        subprocess.check_call('inkscape -e vistrails/gui/resources/images/vistrails_splash.png -w 546 scripts/dist/common/splash/splash.svg'.split())
+        subprocess.check_call([
+            'inkscape',
+            '-e', 'vistrails/gui/resources/images/vistrails_splash.png',
+            '-w', '546',
+            'scripts/dist/common/splash/splash.svg'])
     except (OSError, subprocess.CalledProcessError):
         print "Calling inkscape failed, skipping splash screen update!"

--- a/scripts/dist/windows/Input/runvistrails.py
+++ b/scripts/dist/windows/Input/runvistrails.py
@@ -52,6 +52,10 @@ if len(args) > 3:
     if len(args) > 4:
         filenames = [os.path.abspath(a) for a in args[4:]]
     os.chdir(path)
-    path += os.getenv('PATH')
+    path = (os.path.join(os.path.dirname(python), 'Scripts') +
+            os.pathsep +
+            path +
+            os.pathsep +
+            os.getenv('PATH'))
     os.putenv('PATH', path)
     subprocess.call([python, pyfile] + filenames)

--- a/vistrails/core/vistrail/vistrail.py
+++ b/vistrails/core/vistrail/vistrail.py
@@ -1052,6 +1052,19 @@ class Vistrail(DBVistrail):
                     debug.unexpected_exception(e)
         return package_list
 
+    def get_base_upgrade_version(self, version):
+        """Finds the base version in the upgrade chain.
+        """
+        # TODO: use this in search_upgrade_versions(), once the map is cached
+        upgrade_rev_map = {}
+        for ann in self.action_annotations:
+            if ann.key == Vistrail.UPGRADE_ANNOTATION:
+                upgrade_rev_map[int(ann.value)] = ann.action_id
+
+        while version in upgrade_rev_map:
+            version = upgrade_rev_map[version]
+        return version
+
     def search_upgrade_versions(self, base_version, getter,
                                 start_at_base=None):
         """Search all upgrades from a version for a specific value.

--- a/vistrails/packages/CLTools/init.py
+++ b/vistrails/packages/CLTools/init.py
@@ -88,6 +88,8 @@ def _eintr_retry_call(func, *args):
 def _add_tool(path):
     # first create classes
     tool_name = os.path.basename(path)
+    if isinstance(tool_name, unicode):
+        tool_name = tool_name.encode('utf-8')
     if not tool_name.endswith(SUFFIX): # pragma: no cover
         return
     (tool_name, _) = os.path.splitext(tool_name)
@@ -371,10 +373,10 @@ def _add_tool(path):
     d = """This module is a wrapper for the command line tool '%s'""" % \
         conf['command']
     # create module
-    M = new_module(CLTools, tool_name,{"compute": compute,
-                                           "conf": conf,
-                                           "tool_name": tool_name,
-                                           "__doc__": d})
+    M = new_module(CLTools, tool_name, {"compute": compute,
+                                        "conf": conf,
+                                        "tool_name": tool_name,
+                                        "__doc__": d})
     reg = vistrails.core.modules.module_registry.get_module_registry()
     reg.add_module(M, package=identifiers.identifier,
                    package_version=identifiers.version)


### PR DESCRIPTION
Right now, if the 'name' set on a File module is relative, it will be relative to VisTrails's current working directory (the one it's started from).

This gives the choice between the location of the workflow, VisTrails's installation directory, and the working directory.

The only problem with this is module signatures: if you save your workflow somewhere else, you shouldn't hit the same cache entry.