### PR TITLE
Handles OutputModules in paramexplore

### DIFF
--- a/scripts/create_release_wiki_table.py
+++ b/scripts/create_release_wiki_table.py
@@ -7,8 +7,7 @@ wiki page
 from datetime import date
 #Release version
 VT_VERSION = "2.2"
-VT_REVISION = "b5341fe97287"
-
+VT_REVISION = "b29fb763f234"
 #Sourceforge information
 SF_ROOT_URL = "http://downloads.sourceforge.net/project/vistrails/vistrails/"
 SF_FOLDER_NAME = "v2.2"
@@ -22,11 +21,11 @@ ALL_PLAT_SRC = "vistrails-src-%s-%s.tar.gz"%(VT_VERSION, VT_REVISION)
 USERSGUIDE = "VisTrails.pdf"
 
 #sizes
-MAC_64_SIZE = "182.3 MB"
-WIN_32_SIZE = "125.3 MB"
-WIN_64_SIZE = "150 MB"
-ALL_PLAT_SIZE = "19.2 MB"
-USERSGUIDE_SIZE = "8.7 MB"
+MAC_64_SIZE = "270.2 MB"
+WIN_32_SIZE = "173.9 MB"
+WIN_64_SIZE = "234.6 MB"
+ALL_PLAT_SIZE = "22.3 MB"
+USERSGUIDE_SIZE = "8.9 MB"
 
 def create_text():
     today = date.today().strftime("%Y-%m-%d")

--- a/scripts/dist/windows/common1.iss
+++ b/scripts/dist/windows/common1.iss
@@ -68,6 +68,7 @@ Source: Input\qt.conf; DestDir: {app}\{#python}
 Source: C:\Windows\{#sys}\python27.dll; DestDir: {app}
 Source: C:\Windows\{#sys}\python27.dll; DestDir: {app}\{#python}
 Source: C:\{#prog}\VTK 6.2.0\bin\*.dll; DestDir: {app}
+Source: C:\{#prog}\VTK 6.2.0\bin\*.manifest; DestDir: {app}
 
 ;;;; --------    ALPS FILES    ----------;;;;
 Source: Input\{#bits}\alps_libs\*; DestDir: {app}; Flags: recursesubdirs

--- a/vistrails/core/inspector.py
+++ b/vistrails/core/inspector.py
@@ -162,6 +162,9 @@ class PipelineInspector(object):
         cell_desc = registry.get_descriptor_by_name(
                 'org.vistrails.vistrails.spreadsheet',
                 'SpreadsheetCell')
+        output_desc = registry.get_descriptor_by_name(
+                'org.vistrails.vistrails.basic',
+                'OutputModule')
 
         def find_spreadsheet_cells(pipeline, root_id=None):
             if root_id is None:
@@ -173,6 +176,9 @@ class PipelineInspector(object):
                 # SpreadsheetCell subclasses
                 if registry.is_descriptor_subclass(desc, cell_desc):
                     self.spreadsheet_cells.append(root_id + [mId])
+                # Output modules with a 'spreadsheet' mode
+                elif registry.is_descriptor_subclass(desc, output_desc):
+                    if desc.module.get_mode_class('spreadsheet') is not None:
                         self.spreadsheet_cells.append(root_id + [mId])
 
             for subworkflow_id in self.find_subworkflows(pipeline):

--- a/vistrails/core/inspector.py
+++ b/vistrails/core/inspector.py
@@ -150,35 +150,39 @@ class PipelineInspector(object):
         Inspect the pipeline to see how many cells is needed
         
         """
-        registry = get_module_registry()
         self.spreadsheet_cells = []
-        if not pipeline: return
+        if not pipeline:
+            return
+
+        registry = get_module_registry()
+        # Sometimes we run without the spreadsheet!
+        if not registry.has_module('org.vistrails.vistrails.spreadsheet',
+                                   'SpreadsheetCell'):
+            return
+        cell_desc = registry.get_descriptor_by_name(
+                'org.vistrails.vistrails.spreadsheet',
+                'SpreadsheetCell')
 
         def find_spreadsheet_cells(pipeline, root_id=None):
             if root_id is None:
                 root_id = []
-            # Sometimes we run without the spreadsheet!
-            spreadsheet_pkg = 'org.vistrails.vistrails.spreadsheet'
-            if registry.has_module(spreadsheet_pkg, 'SpreadsheetCell'):
-                # First pass to check cells types
-                cellType = \
-                    registry.get_descriptor_by_name(spreadsheet_pkg,
-                                                    'SpreadsheetCell').module
-                for mId, module in pipeline.modules.iteritems():
-                    desc = registry.get_descriptor_by_name(module.package, 
-                                                           module.name, 
-                                                           module.namespace)
-                    if issubclass(desc.module, cellType):
+            for mId, module in pipeline.modules.iteritems():
+                desc = registry.get_descriptor_by_name(module.package,
+                                                       module.name,
+                                                       module.namespace)
+                # SpreadsheetCell subclasses
+                if registry.is_descriptor_subclass(desc, cell_desc):
+                    self.spreadsheet_cells.append(root_id + [mId])
                         self.spreadsheet_cells.append(root_id + [mId])
 
             for subworkflow_id in self.find_subworkflows(pipeline):
                 subworkflow = pipeline.modules[subworkflow_id]
                 if subworkflow.pipeline is not None:
-                    find_spreadsheet_cells(subworkflow.pipeline, 
+                    find_spreadsheet_cells(subworkflow.pipeline,
                                            root_id + [subworkflow_id])
 
         find_spreadsheet_cells(pipeline)
-    
+
     def find_subworkflows(self, pipeline):
         if not pipeline: 
             return

--- a/vistrails/core/vistrail/module.py
+++ b/vistrails/core/vistrail/module.py
@@ -186,6 +186,8 @@ class Module(DBModule):
         return self.db_has_function_with_id(f_id)
     def get_function_by_real_id(self, f_id):
         return self.db_get_function_by_id(f_id)
+    def delete_function_by_real_id(self, f_id):
+        self.db_delete_function(self.db_get_function_by_id(f_id))
 
     def add_annotation(self, annotation):
         self.db_add_annotation(annotation)

--- a/vistrails/gui/paramexplore/virtual_cell.py
+++ b/vistrails/gui/paramexplore/virtual_cell.py
@@ -658,13 +658,3 @@ class TestCamelCase(unittest.TestCase):
         self.assertEqual(split_camel_case('parseHTML'), 'parse\nHTML')
         self.assertEqual(split_camel_case('HTMLParser'), 'HTML\nParser')
         self.assertEqual(split_camel_case('vHTMLParser'), 'v\nHTML\nParser')
-
-if __name__=="__main__":
-    import sys
-    import vistrails.gui.theme
-    app = QtGui.QApplication(sys.argv)
-    vistrails.gui.theme.initializeCurrentTheme()
-    vc = QVirtualCellConfiguration()
-    vc.configVirtualCells(['VTKCell', 'ImageViewerCell', 'RichTextCell'])
-    vc.show()
-    sys.exit(app.exec_())

--- a/vistrails/packages/spreadsheet/spreadsheet_execute.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_execute.py
@@ -143,12 +143,16 @@ def assignPipelineCellLocations(pipeline, sheetName,
 
     for id_list in cellIds:
         # find at which depth we need to be working
-        id_iter = iter(id_list)
-        mId = next(id_iter)
-        m = pipeline.modules[mId]
-        for mId in id_iter:
-            pipeline = m.pipeline
+        if isinstance(id_list, (int, long)):
+            mId = id_list
             m = pipeline.modules[mId]
+        else:
+            id_iter = iter(id_list)
+            mId = next(id_iter)
+            m = pipeline.modules[mId]
+            for mId in id_iter:
+                pipeline = m.pipeline
+                m = pipeline.modules[mId]
 
         if reg.is_descriptor_subclass(m.module_descriptor,
                                       spreadsheet_cell_desc):

--- a/vistrails/packages/spreadsheet/spreadsheet_execute.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_execute.py
@@ -189,24 +189,26 @@ def assignPipelineCellLocations(pipeline, sheetName,
         pipeline.tmp_id.__class__.getNewId = orig_getNewId
 
     for id_list in cellIds:
+        cell_pipeline = pipeline
+
         # find at which depth we need to be working
         if isinstance(id_list, (int, long)):
             mId = id_list
-            m = pipeline.modules[mId]
+            m = cell_pipeline.modules[mId]
         else:
             id_iter = iter(id_list)
             mId = next(id_iter)
-            m = pipeline.modules[mId]
+            m = cell_pipeline.modules[mId]
             for mId in id_iter:
-                pipeline = m.pipeline
-                m = pipeline.modules[mId]
+                cell_pipeline = m.pipeline
+                m = cell_pipeline.modules[mId]
 
         if reg.is_descriptor_subclass(m.module_descriptor,
                                       spreadsheet_cell_desc):
-            fix_cell_module(pipeline, mId)
+            fix_cell_module(cell_pipeline, mId)
         elif reg.is_descriptor_subclass(m.module_descriptor,
                                         output_module_desc):
-            fix_output_module(pipeline, mId)
+            fix_output_module(cell_pipeline, mId)
 
     return root_pipeline
 

--- a/vistrails/packages/spreadsheet/spreadsheet_execute.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_execute.py
@@ -90,12 +90,10 @@ def assignPipelineCellLocations(pipeline, sheetName,
                                           spreadsheet_cell_desc):
             continue
 
-        # Walk through all connections and remove all CellLocation
-        # modules connected to this spreadsheet cell
+        # Delete connections to 'Location' input port
         conns_to_delete = []
-        for (cId,c) in pipeline.connections.iteritems():
-            if (c.destinationId==mId and
-                pipeline.modules[c.sourceId].name=="CellLocation"):
+        for cId, c in pipeline.connections.iteritems():
+            if c.destinationId==mId and c.source.name == 'Location':
                 conns_to_delete.append(c.id)
         for c_id in conns_to_delete:
             pipeline.delete_connection(c_id)


### PR DESCRIPTION
Fixes #1063

`PipelineInspector` only catches `SpreadsheetCell` subclasses, making paramexplore break if pipelines use `OutputModule` instead.

This makes `PipelineInspector#inspect_spreadsheet_cells()` also find `OutputModule`s if they have a 'spreadsheet' mode. It also updates spreadsheet_execute to correctly set the desired cell location on these, in addition to `SpreadsheetCell` modules.

I had to add a `delete_function_by_real_id()` method to `Module`, I was surprised not to find it. It looks rather inefficient.

Should go into v2.2.