### PR TITLE
Check skipped tests/imports

### DIFF
--- a/vistrails/core/utils/color.py
+++ b/vistrails/core/utils/color.py
@@ -406,6 +406,7 @@ def hsv2rgb(hsv):
 ################################################################################
 
 import unittest
+from vistrails.tests.utils import skip_test_checked
 
 class TestColorByName(unittest.TestCase):
     """
@@ -437,7 +438,7 @@ class TestColorConversion(unittest.TestCase):
         try:
             from PyQt4 import QtGui
         except ImportError:
-            self.skipTest("QtGui not available")
+            skip_test_checked('qt.gui', "QtGui not available")
         for color in self.colors:
             our_hsv = rgb2hsv(color)
             qcolor = QtGui.QColor(*[int(color[i]*255) for i in xrange(3)])

--- a/vistrails/db/services/locator.py
+++ b/vistrails/db/services/locator.py
@@ -1085,6 +1085,7 @@ vistrail_name="%s"/>' % ( self._host, self._port, self._db,
 
 
 import unittest
+from vistrails.tests.utils import skip_test_checked
 
 class TestLocators(unittest.TestCase):
     if not hasattr(unittest.TestCase, 'assertIsInstance'):
@@ -1177,13 +1178,15 @@ class TestLocators(unittest.TestCase):
         enc = sys.getfilesystemencoding() or locale.getpreferredencoding()
         if (enc.lower() not in ('mbcs', 'utf-8', 'utf8',
                                 'latin-1', 'iso-8859-1', 'iso-8859-15')):
-            self.skipTest("unusual encoding on this system: %r" % enc)
+            skip_test_checked('system_encoding',
+                              "unusual encoding on this system: %r" % enc)
         if enc.lower() in ('mbcs', 'latin-1', 'iso-8859-1', 'iso-8859-15'):
             fname = "test_short_names \xE9 \xEA"
         elif enc.lower() in ('utf8', 'utf-8'):
             fname = "test_short_names \xC3\xA9 \xC3\xAA"
         else:
-            self.skipTest("unusual encoding on this system: %r" % enc)
+            skip_test_checked('system_encoding',
+                              "unusual encoding on this system: %r" % enc)
         loc = BaseLocator.from_url("../%s.xml" % fname)
         self.assertEqual(loc.short_filename, fname)
         self.assertEqual(loc.short_name, u"test_short_names \xE9 \xEA")
@@ -1193,8 +1196,9 @@ class TestLocators(unittest.TestCase):
             import ntpath
             import nturl2path
         except ImportError:
-            return self.skipTest("Do not have ntpath or nturl2path installed.")
-            
+            skip_test_checked('path.nt',
+                              "Do not have ntpath or nturl2path installed.")
+
         global systemType
         old_sys_type = systemType
         old_path = os.path

--- a/vistrails/gui/mashups/mashup_app.py
+++ b/vistrails/gui/mashups/mashup_app.py
@@ -41,7 +41,7 @@ from PyQt4.QtCore import pyqtSignal
 from vistrails.core import debug
 from vistrails.gui.mashups.mashups_widgets import QAliasNumericStepperWidget, \
     QAliasSliderWidget, QDropDownWidget
-from vistrails.gui.utils import show_warning, TestVisTrailsGUI
+from vistrails.gui.utils import show_warning
 
 from vistrails.packages.spreadsheet.spreadsheet_controller import \
     spreadsheetController
@@ -610,6 +610,9 @@ class QCustomDockWidget(QtGui.QDockWidget):
 ################################################################################
 # Testing
 
+from vistrails.gui.utils import TestVisTrailsGUI
+from vistrails.tests.utils import skip_test_checked
+
 
 class TestMashupApp(TestVisTrailsGUI):
     def setUp(self):
@@ -617,7 +620,7 @@ class TestMashupApp(TestVisTrailsGUI):
         try:
             import vtk
         except ImportError:
-            self.skipTest("VTK is not available")
+            skip_test_checked('vtk', "VTK is not available")
         from vistrails.tests.utils import enable_package
         enable_package('org.vistrails.vistrails.vtk')
 

--- a/vistrails/packages/persistent_archive/ui.py
+++ b/vistrails/packages/persistent_archive/ui.py
@@ -135,9 +135,12 @@ class VistrailsViewerWindow(StoreViewerWindow):
                     break
 
 
-store = get_default_store()
-viewer = VistrailsViewerWindow(store)
+_viewer = None
 
 
 def show_viewer():
-    viewer.show()
+    global _viewer
+    if _viewer is None:
+        store = get_default_store()
+        _viewer = VistrailsViewerWindow(store)
+    _viewer.show()

--- a/vistrails/packages/tabledata/convert/convert_dates.py
+++ b/vistrails/packages/tabledata/convert/convert_dates.py
@@ -382,7 +382,7 @@ _modules = {'dates': [
 ###############################################################################
 
 import unittest
-from vistrails.tests.utils import execute, intercept_result
+from vistrails.tests.utils import execute, intercept_result, skip_test_checked
 from ..identifiers import identifier
 
 
@@ -450,7 +450,7 @@ class TestStringsToDates(unittest.TestCase):
         try:
             import dateutil
         except ImportError: # pragma: no cover
-            self.skipTest("dateutil is not available")
+            skip_test_checked('dateutil', "dateutil is not available")
 
         dates = ['2013-05-20 9:25',
                  'Thu Sep 25 10:36:26 2003',
@@ -499,10 +499,11 @@ class TestStringsToDates(unittest.TestCase):
         try:
             import pytz
         except ImportError: # pragma: no cover
-            self.skipTest("pytz is not available")
+            skip_test_checked('pytz', "pytz is not available")
         if LooseVersion(pytz.__version__) < PYTZ_MIN_VER: # pragma: no cover
-            self.skipTest("pytz version is known to cause issues (%s)" %
-                          pytz.__version__)
+            skip_test_checked('pytz',
+                              "pytz version is known to cause issues (%s)" %
+                              pytz.__version__)
 
         dates = ['2013-01-20 9:25', '2013-01-20 09:31', '2013-06-02 19:05']
         in_fmt = '%Y-%m-%d %H:%M'
@@ -534,7 +535,7 @@ class TestDatesToMatplotlib(unittest.TestCase):
         try:
             import matplotlib
         except ImportError: # pragma: no cover
-            self.skipTest("matplotlib is not available")
+            skip_test_checked('matplotlib', "matplotlib is not available")
 
         from matplotlib.dates import date2num
 
@@ -577,7 +578,7 @@ class TestTimestampsToMatplotlib(unittest.TestCase):
         try:
             import matplotlib
         except ImportError: # pragma: no cover
-            self.skipTest("matplotlib is not available")
+            skip_test_checked('matplotlib', "matplotlib is not available")
 
         from matplotlib.dates import date2num
 

--- a/vistrails/packages/tabledata/read/read_excel.py
+++ b/vistrails/packages/tabledata/read/read_excel.py
@@ -153,11 +153,11 @@ _modules = [ExcelSpreadsheet]
 
 import itertools
 import unittest
-from vistrails.tests.utils import execute, intercept_result
+from vistrails.tests.utils import execute, intercept_result, skip_if_checked
 from ..identifiers import identifier
 from ..common import ExtractColumn
 
-@unittest.skipIf(get_xlrd() is None, "xlrd not available")
+@skip_if_checked(get_xlrd() is None, 'xlrd', "xlrd not available")
 class ExcelTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/vistrails/packages/tabledata/write/__init__.py
+++ b/vistrails/packages/tabledata/write/__init__.py
@@ -61,6 +61,7 @@ _modules = make_modules_dict(numpy_modules, csv_modules, excel_modules,
 ###############################################################################
 
 import unittest
+from vistrails.tests.utils import skip_if_checked
 
 
 class BaseWriteTestCase(object):
@@ -125,7 +126,7 @@ class BaseWriteTestCase(object):
         self.assertEqual(results[0], ['a', '2', 'c'])
 
 
-@unittest.skipIf(get_xlwt() is None, "xlwt not available")
+@skip_if_checked(get_xlwt() is None, "xlwt not available")
 class ExcelWriteTestCase(unittest.TestCase, BaseWriteTestCase):
     WRITER_MODULE = 'write|WriteExcelSpreadsheet'
     READER_MODULE = 'read|ExcelSpreadsheet'

--- a/vistrails/tests/runtestsuite.py
+++ b/vistrails/tests/runtestsuite.py
@@ -165,7 +165,7 @@ import vistrails.core.debug
 vistrails.core.debug.DebugPrint.getInstance().log_to_console()
 
 import vistrails.tests
-from vistrails.tests.utils import skippable_test
+from vistrails.tests.utils import set_skippable_tests, skippable_test
 import vistrails.core
 import vistrails.core.db.io
 import vistrails.core.db.locator
@@ -178,6 +178,14 @@ from vistrails.core.packagemanager import get_package_manager
 # VisTrails does funny stuff with unittest/unittest2, be sure to load that
 # after vistrails
 import unittest
+
+# Load the skippable test whitelist
+if os.environ.get('VISTRAILS_SKIP_WHITELIST'):
+    set_skippable_tests(os.environ['VISTRAILS_SKIP_WHITELIST'].split(','))
+    print ("Test skipping whitelist enabled; skipping non-whitelisted tests "
+           "will be\nreported as error")
+else:
+    print "No test skipping whitelist; tests will be skipped with no error"
 
 # reinitializing arguments and options so VisTrails does not try parsing them
 sys.argv = sys.argv[:1]

--- a/vistrails/tests/runtestsuite.py
+++ b/vistrails/tests/runtestsuite.py
@@ -165,6 +165,7 @@ import vistrails.core.debug
 vistrails.core.debug.DebugPrint.getInstance().log_to_console()
 
 import vistrails.tests
+from vistrails.tests.utils import skippable_test
 import vistrails.core
 import vistrails.core.db.io
 import vistrails.core.db.locator
@@ -360,9 +361,12 @@ for (p, subdirs, files) in os.walk(root_directory):
                 m = __import__(module)
         except BaseException:
             print >>sys.stderr, "ERROR: Could not import module: %s" % module
-            if verbose >= 1:
-                traceback.print_exc(file=sys.stderr)
-            continue
+            if not skippable_test(module):
+                raise
+            else:
+                if verbose >= 1:
+                    traceback.print_exc(file=sys.stderr)
+                continue
 
         # Load the unittest TestCases
         suite = test_loader.loadTestsFromModule(m)

--- a/vistrails/tests/utils.py
+++ b/vistrails/tests/utils.py
@@ -39,6 +39,7 @@ from __future__ import division
 import contextlib
 import logging
 import sys
+import unittest
 
 try:
     import cStringIO as StringIO
@@ -346,3 +347,103 @@ class MockLogHandler(logging.Handler):
         finally:
             if hasattr(logging, '_acquireLock'):
                 logging._releaseLock()
+
+
+
+class SkippingChecker(object):
+    """This mechanism allows to specify the checks you expect to fail.
+
+    VisTrails has lots of dependencies, some of which not easy to setup.
+    Running the test suite on your machine only tests what is available,
+    skipping over tests that can't run because of missing dependencies.
+
+    However, we want to make sure the right tests run on automated build
+    machines. For that reason, this mechanism allows to specify a whitelist of
+    the tests that are allowed to skip; if a disallowed test skips, an error
+    will be reported so we'll know about it (and add the dependency to the
+    machine, change our requirements, or fix the test if skipping was a
+    mistake).
+    """
+    def __init__(self):
+        self.allowed_tests = None
+
+    def skip_test(self, dependency_specs, reason=None):
+        """Skip this test, if allowed.
+
+        This raises SkipTest, same as unittest.TestCase.skipTest(), except that
+        if a list of skippable tests have been provided, this will fail if the
+        test does not appear in the list.
+
+        This allows the test runner to specify the tests it expects to be
+        skipped, and fail if another test fails.
+
+        There is no need to use this method when skipping a test that cannot
+        run or is known to be broken on the current architecture.
+        """
+        if reason:
+            args = reason,
+        else:
+            args = ()
+
+        if isinstance(dependency_specs, basestring):
+            dependency_specs = dependency_specs,
+
+        # Not using a whitelist; assume this is fine. The fact that this was
+        # skipped will still be logged if the testsuite is verbose
+        if self.allowed_tests is None:
+            raise unittest.SkipTest(*args)
+        # Check against whitelist
+        else:
+            for dep in dependency_specs:
+                path = []
+                for comp in dep.split('.'):
+                    path.append(comp)
+                    if tuple(path) in self.allowed_tests:
+                        raise unittest.SkipTest(*args)
+
+        raise AssertionError("Failing on disallowed SkipTest(%r)" %
+                             ", ".join(args))
+
+    def set_allowed_skips(self, tests):
+        """Sets the tests that can be skipped.
+
+        If tests is not None, skipping a test that doesn't appear in this list
+        will fail instead.
+        """
+        self.allowed_tests = set(tuple(t.split('.')) for t in tests)
+
+
+_test_skipping_checker = SkippingChecker()
+
+skip_test_checked = _test_skipping_checker.skip_test
+set_skippable_tests = _test_skipping_checker.set_allowed_skips
+
+
+class TestSkippingChecker(unittest.TestCase):
+    def do_skip(self, checker, deps, should_raise):
+        try:
+            checker.skip_test(deps)
+        except unittest.SkipTest:
+            if should_raise:
+                self.fail("Skipping this test should have been disallowed")
+        except AssertionError:
+            if not should_raise:
+                self.fail("Skipping this test should have been allowed")
+
+    def test_checker(self):
+        checker = SkippingChecker()
+        checker.set_allowed_skips(['vtk',
+                                   'mpl.hist',
+                                   'sql.postgre', 'sql.mysql'])
+        self.assertEqual(checker.allowed_tests,
+                         set([('vtk',),
+                              ('mpl', 'hist'),
+                              ('sql', 'postgre'), ('sql', 'mysql')]))
+
+        self.do_skip(checker, 'vtk', False)
+        self.do_skip(checker, 'numpy', True)
+        self.do_skip(checker, ['mpl'], True)
+        self.do_skip(checker, ['vtk', 'numpy'], False)
+        self.do_skip(checker, ['vtk.offscreen', 'numpy'], False)
+        self.do_skip(checker, ['sql.oracle'], True)
+        self.do_skip(checker, ['sql.mysql'], False)

--- a/vistrails/tests/utils.py
+++ b/vistrails/tests/utils.py
@@ -45,8 +45,6 @@ try:
 except ImportError:
     import StringIO
 
-from vistrails.core.modules.vistrails_module import Module
-
 
 def enable_package(identifier):
     """Enables a package.
@@ -266,6 +264,8 @@ def intercept_results(*args):
             one1, one2, two1, two2):
         self.assertFalse(execute(...))
     """
+    from vistrails.core.modules.vistrails_module import Module
+
     ctx = []
     current_module = None
     for arg in args:


### PR DESCRIPTION
This allows tests to specify a list of things they need, when they try to skip. If none of this things appears in the `VISTRAILS_SKIP_WHITELIST`, a test failure is reported instead.

This would allow us to specify the things that can't be run on a particular machine (because deps are not installed, or we are running tests headless, or OpenGL doesn't work) and still fail if something unexpected happens (matplotlib doesn't import, file_archive is not installed, pytz is out of date, ...)

Fixes #1028

Some terms should definitely be renamed in this ("dependency", "component", "skippable").

I might have over-engineered this again, but hopefully it's useful. It does mean that we should set the variable on build machines.