### PR TITLE
Fixes lingering toolbar

### DIFF
--- a/vistrails/packages/spreadsheet/spreadsheet_sheet.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_sheet.py
@@ -544,6 +544,8 @@ class StandardWidgetSheet(QtGui.QTableWidget):
         self.setCellWidget(row, col, cellWidget)
         if cellWidget:
             self.delegate.updateEditorGeometry(cellWidget, None, index)
+        if (row, col) == self.activeCell:
+            self.setActiveCell(row, col)
 
     def selectCell(self, row, col, toggling):
         """ selectCell(row: int, col: int, toggling: bool) -> None


### PR DESCRIPTION
Makes the cell toolbar go away when the cell is cleared.

Fixes #1072

I am not sure about this. In particular, since this is triggered synchronously from the toolbar's "clear cell" button, I don't know if that makes a Qt widget commit suicide while it's on the stack.