### PR TITLE
Qt5 fixes

### DIFF
--- a/vistrails/gui/pipeline_view.py
+++ b/vistrails/gui/pipeline_view.py
@@ -568,7 +568,7 @@ class QGraphicsConfigureItem(QtGui.QGraphicsPolygonItem):
         _pen = CurrentTheme.CONFIGURE_PEN
         _brush = CurrentTheme.CONFIGURE_BRUSH
         _shape = CurrentTheme.CONFIGURE_SHAPE
-        QtGui.QGraphicsPolygonItem.__init__(self, _shape, parent, scene)
+        QtGui.QGraphicsPolygonItem.__init__(self, _shape, parent)
         self.setZValue(1)
         self.setPen(_pen)
         self.setBrush(_brush)
@@ -1035,7 +1035,7 @@ class QGraphicsModuleItem(QGraphicsItemInterface, QtGui.QGraphicsItem):
         Create the shape, initialize its pen and brush accordingly
         
         """
-        QtGui.QGraphicsItem.__init__(self, parent, scene)
+        QtGui.QGraphicsItem.__init__(self, parent)
         self.paddedRect = QtCore.QRectF()
         if QtCore.QT_VERSION >= 0x40600:
             #Qt 4.6 specific flags

--- a/vistrails/gui/version_view.py
+++ b/vistrails/gui/version_view.py
@@ -80,7 +80,7 @@ class QGraphicsLinkItem(QGraphicsItemInterface, QtGui.QGraphicsPolygonItem):
         Create the shape, initialize its pen and brush accordingly
         
         """
-        QtGui.QGraphicsPolygonItem.__init__(self, parent, scene)
+        QtGui.QGraphicsPolygonItem.__init__(self, parent)
         self.setFlags(QtGui.QGraphicsItem.ItemIsSelectable)
         self.setZValue(0)
         self.linkPen = CurrentTheme.LINK_PEN
@@ -272,7 +272,7 @@ class QGraphicsVersionTextItem(QGraphicsItemInterface, QtGui.QGraphicsTextItem):
         Create the shape, intialize its drawing style
 
         """
-        QtGui.QGraphicsTextItem.__init__(self, parent, scene)
+        QtGui.QGraphicsTextItem.__init__(self, parent)
         self.timer = None
         self.isEditable = None
         self.setEditable(False)
@@ -406,7 +406,7 @@ class QGraphicsVersionItem(QGraphicsItemInterface, QtGui.QGraphicsEllipseItem):
         Create the shape, initialize its pen and brush accordingly
         
         """
-        QtGui.QGraphicsEllipseItem.__init__(self, parent, scene)
+        QtGui.QGraphicsEllipseItem.__init__(self, parent)
         self.setZValue(1)
         self.setAcceptDrops(True)
         self.setFlags(QtGui.QGraphicsItem.ItemIsSelectable)

--- a/vistrails/gui/vistrails_window.py
+++ b/vistrails/gui/vistrails_window.py
@@ -38,6 +38,7 @@ view and a version tree for each opened Vistrail """
 from __future__ import division
 
 from PyQt4 import QtCore, QtGui
+from xml.sax.saxutils import escape
 import copy
 
 from vistrails.core.configuration import (get_vistrails_configuration,
@@ -1842,7 +1843,7 @@ class QVistrailsWindow(QVistrailViewWindow):
             if name=='':
                 name = 'Untitled%s'%vistrails.core.system.vistrails_default_file_type()
             text = ('Vistrail ' +
-                    QtCore.Qt.escape(name) +
+                    escape(name) +
                     ' contains unsaved changes.\n Do you want to '
                     'save changes before closing it?')
             res = QtGui.QMessageBox.information(window,

--- a/vistrails/packages/spreadsheet/spreadsheet_window.py
+++ b/vistrails/packages/spreadsheet/spreadsheet_window.py
@@ -411,7 +411,8 @@ class SpreadsheetWindow(QtGui.QMainWindow):
             if isinstance(q, QCellContainer):
                 return q.containedWidget!=None
             p = q
-            while (p and (not p.isModal()) and not isinstance(p, StandardWidgetSheet) and p.parent):
+            while (p and not (hasattr(p, 'isModal') and p.isModal()) and
+                   not isinstance(p, StandardWidgetSheet) and p.parent):
                 p = p.parent()
             if p and isinstance(p, StandardWidgetSheet) and not p.isModal():
                 pos = p.viewport().mapFromGlobal(e.globalPos())

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -364,7 +364,6 @@ class QVTKWidget(QCellWidget):
                     version = [v.GetVTKMajorVersion(),
                                v.GetVTKMinorVersion(),
                                v.GetVTKBuildVersion()]
-                    display = hex(display)[2:]
                     if version < [5, 7, 0]:
                         vp = ('_%s_void_p\0x00' % display)
                     elif version < [6, 2, 0]:

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -483,8 +483,10 @@ class QVTKWidget(QCellWidget):
         """
         if system.systemType in ['Windows', 'Microsoft']:
             return None
-        else:
-            return QCellWidget.paintEngine(self)
+        # Qt5 does not use paintEngine, but VTK still calls it?
+        # So we need to disable it
+        #else:
+        #    return QCellWidget.paintEngine(self)
 
     def paintEvent(self, e):
         """ paintEvent(e: QPaintEvent) -> None

--- a/vistrails/packages/vtk/vtkcell.py
+++ b/vistrails/packages/vtk/vtkcell.py
@@ -348,10 +348,17 @@ class QVTKWidget(QCellWidget):
                 display = None
                 try:
                     display = int(QtGui.QX11Info.display())
+                    display = hex(display)[2:]
                 except TypeError:
                     # This was changed for PyQt4.2
                     if isinstance(QtGui.QX11Info.display(), QtGui.Display):
                         display = sip.unwrapinstance(QtGui.QX11Info.display())
+                        display = hex(display)[2:]
+                except AttributeError:
+                    # Qt5 does not have QX11Info
+                    visApp = QtCore.QCoreApplication.instance()
+                    display = visApp.desktop().screenNumber()
+                    print "dissed", display
                 if display is not None:
                     v = vtk.vtkVersion()
                     version = [v.GetVTKMajorVersion(),


### PR DESCRIPTION
We should support Qt 5 and ship it in the binaries (if there are no backwards compatibility issues). The main reason is to support the new WebKit. This will need a recompile of everything using Qt.

This is now working. Just needs some more testing.

* [X] Vistrails runs
* [X] Test with VTK
* [ ] Use WebEngine?
* [ ] More testing needed
* [ ] Update Mac build
* [ ] Update Windows build
