### PR TITLE
Also update temp config when updating persistent

### DIFF
--- a/vistrails/core/bundles/pyimport.py
+++ b/vistrails/core/bundles/pyimport.py
@@ -99,6 +99,9 @@ def py_import(module_name, dependency_dictionary, store_in_config=False):
             ignored_packages.discard(module_name)
         else:
             ignored_packages.add(module_name)
+        setattr(get_vistrails_configuration(),
+                'bundleDeclinedList',
+                ';'.join(sorted(ignored_packages)))
         setattr(get_vistrails_persistent_configuration(),
                 'bundleDeclinedList',
                 ';'.join(sorted(ignored_packages)))

--- a/vistrails/core/thumbnails.py
+++ b/vistrails/core/thumbnails.py
@@ -49,8 +49,7 @@ import mimetypes
 # Remove line below when it is fixed here: http://bugs.python.org/issue15207
 mimetypes.init(files=[])
 from vistrails.core import debug, system
-from vistrails.core.configuration import get_vistrails_configuration, \
-      get_vistrails_persistent_configuration
+from vistrails.core.configuration import get_vistrails_configuration
 from vistrails.core.utils import VistrailsInternalError
 
 ############################################################################

--- a/vistrails/core/vistrail/connection.py
+++ b/vistrails/core/vistrail/connection.py
@@ -35,7 +35,6 @@
 ###############################################################################
 from __future__ import division
 
-from vistrails.core.configuration import get_vistrails_configuration
 """ This python module defines Connection class.
 """
 import copy

--- a/vistrails/gui/job_monitor.py
+++ b/vistrails/gui/job_monitor.py
@@ -40,7 +40,9 @@ import time
 
 from PyQt4 import QtCore, QtGui
 
-from vistrails.core import debug, configuration
+from vistrails.core import debug
+from vistrails.core.configuration import get_vistrails_configuration, \
+    get_vistrails_persistent_configuration
 from vistrails.core.modules.vistrails_module import ModuleSuspended
 from vistrails.gui import theme
 from vistrails.gui.common_widgets import QDockPushButton
@@ -118,7 +120,7 @@ class QJobView(QtGui.QWidget, QVistrailsPaletteInterface):
         self.interval.setEditable(True)
         self.interval.editTextChanged.connect(self.set_refresh)
         self.interval.setValidator(QNumberValidator())
-        conf = configuration.get_vistrails_configuration()
+        conf = get_vistrails_configuration()
         self.interval.setEditText(str(conf.jobCheckInterval))
         buttonsLayout.addWidget(self.interval)
 
@@ -164,8 +166,8 @@ class QJobView(QtGui.QWidget, QVistrailsPaletteInterface):
                 self.set_visible(True)
 
     def autorunToggled(self, value):
-        conf = configuration.get_vistrails_configuration()
-        conf.jobAutorun = value
+        get_vistrails_configuration().jobAutorun = value
+        get_vistrails_persistent_configuration().jobAutorun = value
 
     def set_refresh(self, refresh=0):
         """Changes the timer time.
@@ -188,8 +190,8 @@ class QJobView(QtGui.QWidget, QVistrailsPaletteInterface):
             if self.timer_id:
                 self.killTimer(self.timer_id)
                 self.timer_id = None
-        conf = configuration.get_vistrails_persistent_configuration()
-        conf.jobCheckInterval = refresh
+        get_vistrails_configuration().jobCheckInterval = refresh
+        get_vistrails_persistent_configuration().jobCheckInterval = refresh
         self.updating_now = False
 
     def update_jobs(self):
@@ -412,7 +414,7 @@ class QVistrailItem(QtGui.QTreeWidgetItem):
         workflow_item.updateJobs()
         progress = self.controller.progress
 
-        conf = configuration.get_vistrails_configuration()
+        conf = get_vistrails_configuration()
         interval = conf.jobCheckInterval
         if interval and not conf.jobAutorun and not progress.suspended:
             # we should keep checking the job


### PR DESCRIPTION
This makes sure the temp_configuration also gets updated when changing the persistent_configuration.

Fixes #1084

attn @rexissimus: touches job monitor gui

Should go on v2.2.