### PR TITLE
Try not to show upgrade changes in diffs

### DIFF
--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -4284,6 +4284,28 @@ class VistrailController(object):
         #return module move operations
         return self.move_modules_ops(moves)
 
+    def create_upgrade(self, version):
+        """ Upgrade a version without doing version switch
+
+        """
+        try:
+            self.flush_delayed_actions()
+            version = self.vistrail.get_upgrade(version) or version
+            pipeline = self.vistrail.getPipeline(version)
+            self.validate(pipeline)
+        except InvalidPipeline as e:
+            # switch version to trigger upgrade
+            # but try to avoid switching version in GUI
+            # put vistrail in new controller, do upgrade, put vistrail back
+            controller = VistrailController(self.vistrail, auto_save=False)
+            try:
+                controller.do_version_switch(version, True)
+                controller.flush_delayed_actions()
+            except InvalidPipeline as e:
+                pass
+            version = controller.current_version
+        return version
+
 
 import unittest
 

--- a/vistrails/gui/collection/workspace.py
+++ b/vistrails/gui/collection/workspace.py
@@ -1033,22 +1033,22 @@ class QVistrailList(QtGui.QTreeWidget):
         destination_parent = destination.parent()
         while not hasattr(destination_parent, 'window'):
             destination_parent = destination_parent.parent()
-        vistrail_1 = source_parent.window.controller.vistrail
-        vistrail_2 = destination_parent.window.controller.vistrail
+        controller_1 = source_parent.window.controller
+        controller_2 = destination_parent.window.controller
         if hasattr(source, 'entity'):
             v1 = source.entity.locator().kwargs.get('version_node', None)
         else:
-            v1 = vistrail_1.get_latest_version()
+            v1 = controller_1.vistrail.get_latest_version()
         if hasattr(destination, 'entity'):
             v2 = destination.entity.locator().kwargs.get('version_node', None)
         else:
-            v2 = vistrail_2.get_latest_version()
+            v2 = controller_2.vistrail.get_latest_version()
         
         # if we don't have the same vistrail, pass the second vistrail
-        if id(vistrail_1) == id(vistrail_2):
+        if id(controller_1) == id(controller_2):
             source_parent.window.diff_requested(v1, v2)
         else:
-            source_parent.window.diff_requested(v1, v2, vistrail_2)
+            source_parent.window.diff_requested(v1, v2, controller_2)
             
     def hideExecutions(self, hidden):
         self.executionsHidden = hidden

--- a/vistrails/gui/vis_diff.py
+++ b/vistrails/gui/vis_diff.py
@@ -367,11 +367,23 @@ class QDiffProperties(QtGui.QWidget, QVistrailsPaletteInterface):
         ((vistrail_a, version_a), (vistrail_b, version_b)) = \
             self.controller.current_diff_versions
 
+        hideUpgrades = getattr(get_vistrails_configuration(), 'hideUpgrades',
+                               True)
         # Set up the version name correctly
-        v1_name = vistrail_a.getVersionName(version_a)
+        if hideUpgrades:
+            v1_name = vistrail_a.search_upgrade_versions(
+                version_a,
+                lambda vt, v, bv: vt.getVersionName(v) or None) or ''
+        else:
+            v1_name = vistrail_a.getVersionName(version_a)
         if not v1_name:
             v1_name = 'Version %d' % version_a
-        v2_name = vistrail_b.getVersionName(version_b)
+        if hideUpgrades:
+            v2_name = vistrail_b.search_upgrade_versions(
+                version_b,
+                lambda vt, v, bv: vt.getVersionName(v) or None) or ''
+        else:
+            v2_name = vistrail_b.getVersionName(version_b)
         if not v2_name:
             v2_name = 'Version %d' % version_b
 

--- a/vistrails/gui/vis_diff.py
+++ b/vistrails/gui/vis_diff.py
@@ -38,17 +38,16 @@ operation """
 from __future__ import division
 
 from PyQt4 import QtCore, QtGui
+from vistrails.core import system, debug
+from vistrails.core.configuration import get_vistrails_configuration
 from vistrails.core.system import get_vistrails_basic_pkg_id
 from vistrails.core.utils import VistrailsInternalError
-from vistrails.core.utils.color import ColorByName
-from vistrails.core.vistrail.abstraction import Abstraction
 from vistrails.core.vistrail.pipeline import Pipeline
 from vistrails.core.vistrail.port_spec import PortSpec
 from vistrails.gui.pipeline_view import QPipelineView
 from vistrails.gui.theme import CurrentTheme
-from vistrails.gui.vistrail_controller import VistrailController
+from vistrails.gui.utils import TestVisTrailsGUI
 from vistrails.gui.vistrails_palette import QVistrailsPaletteInterface
-from vistrails.core import system, debug
 import vistrails.core.db.io
 
 import copy
@@ -1311,3 +1310,39 @@ class QVisualDiff(QtGui.QMainWindow):
 
         scene.updateSceneBoundingRect()
         scene.fitToView(self.pipelineView, True)
+
+
+################################################################################
+# Testing
+
+
+class TestDiffView(TestVisTrailsGUI):
+    def setUp(self):
+        try:
+            import vtk
+        except ImportError:
+            self.skipTest("VTK is not available")
+        from vistrails.tests.utils import enable_package
+        enable_package('org.vistrails.vistrails.vtk')
+
+    def test_diff(self):
+        import vistrails.api
+        import vistrails.core.system
+        import os.path
+        from vistrails.core.configuration import get_vistrails_configuration
+        filename = os.path.join(
+            vistrails.core.system.vistrails_root_directory(),
+            '..', 'examples', 'terminator.vt')
+        view = vistrails.api.open_vistrail_from_file(filename)
+        # get tags
+        v1 = view.controller.vistrail.get_version_number('Volume Rendering HW')
+        v2 = view.controller.vistrail.get_version_number('Volume Rendering SW')
+
+        hideUpgrades = getattr(get_vistrails_configuration(), 'hideUpgrades', True)
+        # without upgrades
+        setattr(get_vistrails_configuration(), 'hideUpgrades', False)
+        view.diff_requested(v1, v2)
+        # with upgrades
+        setattr(get_vistrails_configuration(), 'hideUpgrades', True)
+        view.diff_requested(v1, v2)
+        setattr(get_vistrails_configuration(), 'hideUpgrades', hideUpgrades)

--- a/vistrails/gui/vis_diff.py
+++ b/vistrails/gui/vis_diff.py
@@ -1344,8 +1344,9 @@ class TestDiffView(TestVisTrailsGUI):
         from vistrails.core.configuration import get_vistrails_configuration
         filename = os.path.join(
             vistrails.core.system.vistrails_root_directory(),
-            '..', 'examples', 'terminator.vt')
+            'tests', 'resources', 'terminator.vt')
         view = vistrails.api.open_vistrail_from_file(filename)
+        view.controller.change_selected_version(0)
         # get tags
         v1 = view.controller.vistrail.get_version_number('Volume Rendering HW')
         v2 = view.controller.vistrail.get_version_number('Volume Rendering SW')

--- a/vistrails/gui/vistrail_view.py
+++ b/vistrails/gui/vistrail_view.py
@@ -866,6 +866,12 @@ class QVistrailView(QtGui.QWidget):
         view.
         """
 
+        # Upgrade both versions if hiding upgrades
+        if getattr(get_vistrails_configuration(), 'hideUpgrades', True):
+            vt_a = self.controller.vistrail
+            vt_b = vistrail_b or vt_a
+            version_a = vt_a.get_upgrade(version_a) or version_a
+            version_b = vt_b.get_upgrade(version_b) or version_b
         view = self.create_diff_view()
         view.set_controller(self.controller)
         view.set_diff(version_a, version_b, vistrail_b)

--- a/vistrails/gui/vistrail_view.py
+++ b/vistrails/gui/vistrail_view.py
@@ -857,24 +857,25 @@ class QVistrailView(QtGui.QWidget):
         window = self.window()
         window.qactions['search'].trigger()
         
-    def diff_requested(self, version_a, version_b, vistrail_b=None):
+    def diff_requested(self, version_a, version_b, controller_b=None):
         """diff_requested(self, id, id, Vistrail) -> None
         
-        Request a diff between two versions.  If vistrail_b is
+        Request a diff between two versions.  If controller_b is
         specified, the second version will be derived from that
         vistrail instead of the common vistrail controlled by this
         view.
         """
-
         # Upgrade both versions if hiding upgrades
         if getattr(get_vistrails_configuration(), 'hideUpgrades', True):
             vt_a = self.controller.vistrail
-            vt_b = vistrail_b or vt_a
-            version_a = vt_a.get_upgrade(version_a) or version_a
-            version_b = vt_b.get_upgrade(version_b) or version_b
+            controller_b = controller_b or self.controller
+            vt_b = controller_b.vistrail
+            version_a = self.controller.create_upgrade(version_a)
+            version_b = controller_b.create_upgrade(version_b)
+
         view = self.create_diff_view()
         view.set_controller(self.controller)
-        view.set_diff(version_a, version_b, vistrail_b)
+        view.set_diff(version_a, version_b, controller_b.vistrail)
         self.switch_to_tab(view.tab_idx)
         view.scene().fitToView(view, True)
         self.view_changed()

--- a/vistrails/gui/vistrail_view.py
+++ b/vistrails/gui/vistrail_view.py
@@ -865,11 +865,9 @@ class QVistrailView(QtGui.QWidget):
         vistrail instead of the common vistrail controlled by this
         view.
         """
+        controller_b = controller_b or self.controller
         # Upgrade both versions if hiding upgrades
         if getattr(get_vistrails_configuration(), 'hideUpgrades', True):
-            vt_a = self.controller.vistrail
-            controller_b = controller_b or self.controller
-            vt_b = controller_b.vistrail
             version_a = self.controller.create_upgrade(version_a)
             version_b = controller_b.create_upgrade(version_b)
 


### PR DESCRIPTION
Currently, when diff'ing versions, a lot of modules can appear as deleted and recreated (in the same location) because of upgrades.

Now that we have a 'hideUpgrades' setting controlling whether we want to see the upgrades or hide them (#1046), it makes sense to hide them from the diff in the default setting. To do that, we can simply upgrade both versions before comparing.

This currently only use the upgraded version if it exists, creating a temporary ("delayed") upgrade version might be possible as well.