### PR TITLE
Fix IPythonMode auto-detection

### DIFF
--- a/vistrails/core/api.py
+++ b/vistrails/core/api.py
@@ -104,6 +104,22 @@ def initialize():
     return True
 
 
+def ipython_mode(use_notebook=True):
+    """Selects whether the IPython notebook should be used.
+
+    Call ``vistrails.ipython_mode(True)`` to enable IPythonMode for output
+    modules, directing supported output to the notebook instead of files.
+    """
+    if use_notebook:
+        try:
+            import IPython.core.display
+        except ImportError:
+            raise ValueError("IPython doesn't seem to be installed!?")
+
+    from vistrails.core.modules.output_modules import IPythonMode
+    IPythonMode.notebook_override = use_notebook
+
+
 class Vistrail(object):
     """This class wraps both Vistrail and VistrailController.
 

--- a/vistrails/core/modules/output_modules.py
+++ b/vistrails/core/modules/output_modules.py
@@ -595,13 +595,16 @@ class IPythonMode(OutputMode):
     @staticmethod
     def can_compute():
         try:
-            import __main__ as main
-            if hasattr(main, '__file__'):
-                return False
             import IPython.core.display
-            return True
+            from IPython import get_ipython
+            from IPython.kernel.zmq.zmqshell import ZMQInteractiveShell
         except ImportError:
             return False
+        else:
+            ip = get_ipython()
+            if ip is None or not isinstance(ip, ZMQInteractiveShell):
+                return False
+            return True
 
     def compute_output(self, output_module, configuration):
         from IPython.core.display import display

--- a/vistrails/core/modules/output_modules.py
+++ b/vistrails/core/modules/output_modules.py
@@ -40,6 +40,7 @@ from copy import copy
 import os
 import sys
 import unittest
+import warnings
 
 from vistrails.core.configuration import ConfigurationObject, ConfigField, ConfigPath, get_vistrails_persistent_configuration, get_vistrails_temp_configuration
 from vistrails.core.modules.vistrails_module import Module, NotCacheable, ModuleError
@@ -609,6 +610,12 @@ class IPythonMode(OutputMode):
             ip = get_ipython()
             if ip is None or not isinstance(ip, ZMQInteractiveShell):
                 return False
+            warnings.warn("Looks like we're running from the notebook; "
+                          "automatically enabling IPythonMode.\n"
+                          "If this is right, please call "
+                          "vistrails.ipython_mode(True) so that this keeps "
+                          "working in the future (and this warning doesn't "
+                          "show).")
             return True
 
     def compute_output(self, output_module, configuration):

--- a/vistrails/core/modules/output_modules.py
+++ b/vistrails/core/modules/output_modules.py
@@ -592,8 +592,13 @@ class IPythonMode(OutputMode):
     priority = 400
     config_cls = IPythonModeConfig
 
-    @staticmethod
-    def can_compute():
+    # Set this to enable/disable notebook integration
+    notebook_override = None
+
+    @classmethod
+    def can_compute(cls):
+        if cls.notebook_override is not None:
+            return cls.notebook_override
         try:
             import IPython.core.display
             from IPython import get_ipython


### PR DESCRIPTION
Fix #1089

Makes IPython notebook auto-detection more reliable (hopefully), an `ipython_mode(True|False)` explicit call, and a warning if the notebook gets auto-enabled (`ipython_mode()` not called).