### PR TITLE
Use config 'outputDirectory' in FileMode

### DIFF
--- a/vistrails/core/console_mode.py
+++ b/vistrails/core/console_mode.py
@@ -57,9 +57,9 @@ import vistrails.db
 
 
 ################################################################################
-    
-def run_and_get_results(w_list, parameters='', output_dir=None, 
-                        update_vistrail=True, extra_info=None, 
+
+def run_and_get_results(w_list, parameters='',
+                        update_vistrail=True, extra_info=None,
                         reason='Console Mode Execution'):
     """run_and_get_results(w_list: list of (locator, version), parameters: str,
                            output_dir:str, update_vistrail: boolean,
@@ -156,7 +156,7 @@ def run_and_get_results(w_list, parameters='', output_dir=None,
 
 ################################################################################
 
-def get_wf_graph(w_list, output_dir=None, pdf=False):
+def get_wf_graph(w_list, output_dir, pdf=False):
     """run_and_get_results(w_list: list of (locator, version), 
                            output_dir:str, pdf:bool)
     Load all workflows in wf_list and dump their graph to output_dir.
@@ -188,8 +188,7 @@ def get_wf_graph(w_list, output_dir=None, pdf=False):
 
                 controller.change_selected_version(version)
 
-                if (output_dir is not None and
-                    controller.current_pipeline is not None):
+                if controller.current_pipeline is not None:
                     controller.updatePipelineScene()
                     if pdf:
                         base_fname = "%s_%s_pipeline.pdf" % \
@@ -252,14 +251,14 @@ def get_vt_graph(vt_list, tree_info, pdf=False):
 
 ################################################################################
 
-def run(w_list, parameters='', output_dir=None, update_vistrail=True,
+def run(w_list, parameters='', update_vistrail=True,
         extra_info=None, reason="Console Mode Execution"):
     """run(w_list: list of (locator, version), parameters: str) -> boolean
     Run all workflows in w_list, version can be a tag name or a version id.
     Returns list of errors (empty list if there are no errors)
     """
     all_errors = []
-    results = run_and_get_results(w_list, parameters, output_dir, 
+    results = run_and_get_results(w_list, parameters,
                                   update_vistrail,extra_info, reason)
     for result in results:
         (objs, errors, executed) = (result.objects,

--- a/vistrails/core/modules/output_modules.py
+++ b/vistrails/core/modules/output_modules.py
@@ -486,10 +486,13 @@ class FileMode(OutputMode):
             if suffix is None:
                 suffix = ''
             if dirname is None:
-                # FIXME should unify with VisTrails output
-                # directory global!  should check for abspath (if
-                # not, use relative to global output directory)
                 dirname = ''
+            if not os.path.isabs(dirname):
+                vt_output_dir = getattr(get_vistrails_temp_configuration(),
+                                        'outputDirectory',
+                                        None)
+                if vt_output_dir:
+                    dirname = os.path.join(vt_output_dir, dirname)
 
             # seriesPadding and series have defaults so no
             # need to default them

--- a/vistrails/gui/application.py
+++ b/vistrails/gui/application.py
@@ -548,21 +548,17 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
                         errs.append("Error generating vistrail graph: %s" % \
                                     r[1])
                         debug.critical("*** Error in get_vt_graph: %s" % r[1])
-                
-            extra_info = None
-            if output_dir:
-                extra_info = {'pathDumpCells': output_dir}
+
             if not self.temp_configuration.check('noExecute'):
                 if self.temp_configuration.check('parameterExploration'):
                     errs.extend(
                         vistrails.core.console_mode.run_parameter_explorations(
-                            w_list, extra_info=extra_info))
+                            w_list))
                 else:
                     errs.extend(vistrails.core.console_mode.run(
                             w_list,
                             self.temp_configuration.check('parameters') or '',
-                            update_vistrail=True,
-                            extra_info=extra_info))
+                            update_vistrail=True))
                 if len(errs) > 0:
                     for err in errs:
                         print err

--- a/vistrails/gui/application.py
+++ b/vistrails/gui/application.py
@@ -532,7 +532,7 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
 
             errs = []
             if self.temp_configuration.check('outputPipelineGraph'):
-                results = vistrails.core.console_mode.get_wf_graph(w_list, output_dir,
+                results = vistrails.core.console_mode.get_wf_graph(w_list, output_dir or '',
                                                                    self.temp_configuration.graphsAsPdf)
                 for r in results:
                     if r[0] is False:
@@ -541,7 +541,7 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
                         debug.critical("*** Error in get_wf_graph: %s" % r[1])
             
             if self.temp_configuration.check('outputVersionTree'):
-                results = vistrails.core.console_mode.get_vt_graph(vt_list, output_dir,
+                results = vistrails.core.console_mode.get_vt_graph(vt_list, output_dir or '',
                                                                    self.temp_configuration.graphsAsPdf)
                 for r in results:
                     if r[0] is False:
@@ -561,7 +561,6 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
                     errs.extend(vistrails.core.console_mode.run(
                             w_list,
                             self.temp_configuration.check('parameters') or '',
-                            output_dir if self.temp_configuration.check('withWorkflowInfo') else None,
                             update_vistrail=True,
                             extra_info=extra_info))
                 if len(errs) > 0:

--- a/vistrails/run.py
+++ b/vistrails/run.py
@@ -152,8 +152,7 @@ def main():
                 traceback._format_final_exc_line(type(e).__name__, e).strip())
         traceback.print_exc(None, sys.stderr)
         sys.exit(255)
-    if (not app.temp_configuration.batch and
-        not app.temp_configuration.check('outputDirectory')):
+    if not app.temp_configuration.batch:
         v = app.exec_()
 
     vistrails.gui.application.stop_application()


### PR DESCRIPTION
Mentioned in yesterday's meeting: 'outputDirectory' setting should be used.

Additionally, it looks like 'outputDirectory' is more than the default output path: if it is set, VisTrails is running in some kind of batch mode? See [condition in run.py](https://github.com/VisTrails/VisTrails/blob/cfaff399dfa45e18f497e62f2585f62f1e14d7b6/vistrails/run.py#L156).

'outputDirectory' is not documented in configuration.py (neither is 'graphsAsPdf').


Should go in v2.2.