### PR TITLE
Don't enable IPythonMode if IPython is detected

### DIFF
--- a/vistrails/core/modules/output_modules.py
+++ b/vistrails/core/modules/output_modules.py
@@ -608,15 +608,16 @@ class IPythonMode(OutputMode):
             return False
         else:
             ip = get_ipython()
-            if ip is None or not isinstance(ip, ZMQInteractiveShell):
-                return False
-            warnings.warn("Looks like we're running from the notebook; "
-                          "automatically enabling IPythonMode.\n"
-                          "If this is right, please call "
-                          "vistrails.ipython_mode(True) so that this keeps "
-                          "working in the future (and this warning doesn't "
-                          "show).")
-            return True
+            if ip is not None and isinstance(ip, ZMQInteractiveShell):
+                warnings.warn(
+                        "Looks like you might be running from IPython; you "
+                        "might want to call\nvistrails.ipython_mode(True) to "
+                        "enable IPythonMode, allowing output modules to\n"
+                        "render to the notebook.\n"
+                        "If this is wrong, please call "
+                        "vistrails.ipython_mode(False) to get rid of this\n"
+                        "warning.")
+            return False
 
     def compute_output(self, output_module, configuration):
         from IPython.core.display import display


### PR DESCRIPTION
We now require `vistrails.ipython_mode(True)` to be called before IPythonMode can be used. This is similar to the `%matplotlib inline` magic.

Contrary to #1090 this changes the behavior when ipython_mode() is not called.

Fixes #1089 (again).


Should go in v2.2.