### PR TITLE
Prevents the user from introducing cycles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 RELEASE NOTES
 -------------
+Release Name: v2.2.2 build ??? from v2.2 branch
+
+Bug fixes:
+ - prevents introducing cycles in pipeline view (#1097)
+
 Release Name: v2.2.1 build c366dbcb640c from v2.2 branch
 
 Bug fixes:

--- a/vistrails/core/data_structures/graph.py
+++ b/vistrails/core/data_structures/graph.py
@@ -51,6 +51,13 @@ from vistrails.core.utils import all
 class GraphException(Exception):
     pass
 
+class GraphContainsCycles(GraphException):
+    def __init__(self, v1, v2):
+        self.back_edge = (v1, v2)
+    def __str__(self):
+        return ("Graph contains cycles: back edge %s encountered" %
+                (self.back_edge,))
+
 class Graph(object):
     """Graph holds a graph with possible multiple edges. The
     datastructures are all dictionary-based, so datatypes more general than ints
@@ -403,12 +410,8 @@ class Graph(object):
                     visited.add(to)
         return parent
 
-    class GraphContainsCycles(GraphException):
-        def __init__(self, v1, v2):
-            self.back_edge = (v1, v2)
-        def __str__(self):
-            return ("Graph contains cycles: back edge %s encountered" %
-                    self.back_edge)
+    # For legacy reasons, moved after 2.2.1
+    GraphContainsCycles = GraphContainsCycles
 
     def dfs(self,
             vertex_set=None,
@@ -456,7 +459,7 @@ class Graph(object):
                 if leave_vertex:
                     leave_vertex(w)
             elif edgetype == back and raise_if_cyclic:
-                raise self.GraphContainsCycles(v, w)
+                raise GraphContainsCycles(v, w)
 
         visited = set()
         gray = set()
@@ -557,7 +560,7 @@ class Graph(object):
         try:
             x.vertices_topological_sort()
             return True
-        except self.GraphContainsCycles:
+        except GraphContainsCycles:
             return False
 
     ##########################################################################
@@ -866,7 +869,7 @@ class TestGraph(unittest.TestCase):
         g.add_edge(0, 1)
         g.add_edge(1, 2)
         g.add_edge(2, 0)
-        with self.assertRaises(Graph.GraphContainsCycles):
+        with self.assertRaises(GraphContainsCycles):
             g.dfs(raise_if_cyclic=True)
 
     def test_call_inverse(self):

--- a/vistrails/core/packagemanager.py
+++ b/vistrails/core/packagemanager.py
@@ -665,7 +665,7 @@ class PackageManager(object):
         try:
             g = self._dependency_graph.inverse_immutable()
             sorted_packages = g.vertices_topological_sort()
-        except vistrails.core.data_structures.graph.Graph.GraphContainsCycles, e:
+        except vistrails.core.data_structures.graph.GraphContainsCycles, e:
             raise self.DependencyCycle(e.back_edge[0],
                                        e.back_edge[1])
 
@@ -872,7 +872,7 @@ class PackageManager(object):
     def get_ordered_dependencies(self, dep_graph, identifiers=None):
         try:
             sorted_packages = dep_graph.vertices_topological_sort(identifiers)
-        except vistrails.core.data_structures.graph.Graph.GraphContainsCycles, e:
+        except vistrails.core.data_structures.graph.GraphContainsCycles, e:
             raise self.DependencyCycle(e.back_edge[0],
                                        e.back_edge[1])
         return list(reversed(sorted_packages))

--- a/vistrails/core/vistrail/pipeline.py
+++ b/vistrails/core/vistrail/pipeline.py
@@ -1125,8 +1125,10 @@ class Pipeline(DBWorkflow):
 
         """
         result = []
-        is_upstream = module_ids
+        is_upstream = bool(module_ids)
+        # Might raise GraphContainsCycles
         for module_id in self.graph.vertices_topological_sort():
+            # Skip until we find a module that's in module_ids
             if is_upstream:
                 if module_id in module_ids:
                     is_upstream = False

--- a/vistrails/core/vistrail/pipeline.py
+++ b/vistrails/core/vistrail/pipeline.py
@@ -40,7 +40,7 @@ from __future__ import division
 from vistrails.core.cache.hasher import Hasher
 from vistrails.core.configuration import get_vistrails_configuration
 from vistrails.core.data_structures.bijectivedict import Bidict
-from vistrails.core.data_structures.graph import Graph
+from vistrails.core.data_structures.graph import Graph, GraphContainsCycles
 from vistrails.core import debug
 from vistrails.core.modules.module_registry import get_module_registry, \
     ModuleRegistryException, MissingModuleVersion, MissingPackage, PortMismatch
@@ -852,6 +852,12 @@ class Pipeline(DBWorkflow):
             self.ensure_modules_are_on_registry()
         except InvalidPipeline, e:
             exceptions.update(e.get_exception_set())
+
+        # check for cycles
+        try:
+            self.graph.dfs(raise_if_cyclic=True)
+        except GraphContainsCycles, e:
+            exceptions.add(e)
 
         # do this before we check connection specs because it is
         # possible that a subpipeline invalidates the module, meaning

--- a/vistrails/core/vistrail/pipeline.py
+++ b/vistrails/core/vistrail/pipeline.py
@@ -1124,16 +1124,10 @@ class Pipeline(DBWorkflow):
         affects downstream. This slightly increases performance.
 
         """
+        # TODO: module_ids is currently ignored, this is potentially suboptimal
         result = []
-        is_upstream = bool(module_ids)
         # Might raise GraphContainsCycles
         for module_id in self.graph.vertices_topological_sort():
-            # Skip until we find a module that's in module_ids
-            if is_upstream:
-                if module_id in module_ids:
-                    is_upstream = False
-                else:
-                    continue
             module = self.get_module_by_id(module_id)
             module.list_depth = 0
             ports = []

--- a/vistrails/gui/pipeline_view.py
+++ b/vistrails/gui/pipeline_view.py
@@ -2765,10 +2765,17 @@ class QPipelineScene(QInteractiveGraphicsScene):
             return
         if (self.controller.current_pipeline and
                 self.controller.current_pipeline.is_valid):
-            for module_id, list_depth in \
-                    self.controller.current_pipeline.mark_list_depth(modules):
-                if module_id in self.modules:
-                    self.modules[module_id].module.list_depth = list_depth
+            try:
+                depths = \
+                    self.controller.current_pipeline.mark_list_depth(modules)
+            except GraphContainsCycles:
+                # Pipeline is invalid, we don't really care that the depths are
+                # not right
+                pass
+            else:
+                for module_id, list_depth in depths:
+                    if module_id in self.modules:
+                        self.modules[module_id].module.list_depth = list_depth
         for c in self.connections.itervalues():
             c.setupConnection()
 

--- a/vistrails/gui/pipeline_view.py
+++ b/vistrails/gui/pipeline_view.py
@@ -1072,7 +1072,6 @@ class QGraphicsModuleItem(QGraphicsItemInterface, QtGui.QGraphicsItem):
         self.invalid = False
         self._module_shape = None
         self._original_module_shape = None
-        self._old_connection_ids = None
         self.errorTrace = None
         self.is_breakpoint = False
         self._needs_state_updated = True
@@ -2057,6 +2056,8 @@ class QPipelineScene(QInteractiveGraphicsScene):
         self.noUpdate = False
         self.installEventFilter(self)
         self.pipeline_tab = None
+        # These are the IDs currently present in the scene, used to update it
+        # faster when switching pipelines via setupScene()
         self._old_module_ids = set()
         self._old_connection_ids = set()
         self._var_selected_port = None
@@ -2198,9 +2199,8 @@ class QPipelineScene(QInteractiveGraphicsScene):
         selected = self.modules[m_id].isSelected()
         depending_connections = \
             [c_id for c_id in self.modules[m_id].dependingConnectionItems()]
-        # old_depending_connections = self.modules[m_id]._old_connection_ids
         
-        #when configuring a python source, maybe connections were deleted
+        # when configuring a python source, maybe connections were deleted
         # but are not in the current pipeline. So we need to check the depending
         # connections of the module just before the configure. 
         for c_id in depending_connections:


### PR DESCRIPTION
This checks for cycles in `Pipeline#validate()̀`, and in `QPipelineScene`.

Fixes #1097

Targets v2.2