### PR TITLE
Remove weakref in set_vistrails_application()

### DIFF
--- a/vistrails/core/application.py
+++ b/vistrails/core/application.py
@@ -37,7 +37,6 @@ from __future__ import division
 
 import os
 import sys
-import weakref
 import warnings
 
 from vistrails.core import debug
@@ -71,12 +70,12 @@ def finalize_vistrails(app):
 
 def get_vistrails_application():
     if VistrailsApplication is not None:
-        return VistrailsApplication()
+        return VistrailsApplication
     return None
 
 def set_vistrails_application(app):
     global VistrailsApplication
-    VistrailsApplication = weakref.ref(app, finalize_vistrails)
+    VistrailsApplication = app
 
 def is_running_gui():
     app = get_vistrails_application()


### PR DESCRIPTION
This is not actually useful, and in fact causes problems if the application dies too soon.

finalize_vistrails() was not guaranteed to be called either when the reference drop, since this would usually happen when the interpreter is shutting down.

Fixes #1103

Should go on v2.2