### PR TITLE
Dont pass MplFigure

### DIFF
--- a/vistrails/packages/matplotlib/bases.py
+++ b/vistrails/packages/matplotlib/bases.py
@@ -94,29 +94,30 @@ class MplFigure(Module):
                     ("figureProperties", "(MplFigureProperties)"),
                     ("setLegend", "(MplLegend)")]
 
-    _output_ports = [("self", "(MplFigure)")]
+    _output_ports = [("figure", "(MplFigure)")]
 
     def compute(self):
         # Create a figure
-        self.figInstance = pylab.figure()
+        figInstance = pylab.figure()
         pylab.hold(True)
 
         # Run the plots
         plots = self.get_input("addPlot")
         for plot in plots:
-            plot(self.figInstance)
+            plot(figInstance)
 
         if self.has_input("figureProperties"):
             figure_props = self.get_input("figureProperties")
-            figure_props.update_props(self.figInstance)
+            figure_props.update_props(figInstance)
         if self.has_input("axesProperties"):
             axes_props = self.get_input("axesProperties")
-            axes_props.update_props(self.figInstance.gca())
+            axes_props.update_props(figInstance.gca())
         if self.has_input("setLegend"):
             legend = self.get_input("setLegend")
-            self.figInstance.gca().legend()
+            figInstance.gca().legend()
 
-        self.set_output("self", self)
+        self.set_output("figure", figInstance)
+
 
 class MplContourSet(Module):
     pass
@@ -129,7 +130,7 @@ class MplFigureToFile(ImageFileMode):
     formats = ['pdf', 'png', 'jpg']
 
     def compute_output(self, output_module, configuration):
-        value = output_module.get_input('value')
+        figure = output_module.get_input('value')
         w = configuration["width"]
         h = configuration["height"]
         img_format = self.get_format(configuration)
@@ -137,8 +138,7 @@ class MplFigureToFile(ImageFileMode):
 
         w_inches = w / 72.0
         h_inches = h / 72.0
-        figure = value.figInstance
-        
+
         previous_size = tuple(figure.get_size_inches())
         figure.set_size_inches(w_inches, h_inches)
         canvas = FigureCanvasBase(figure)
@@ -163,7 +163,7 @@ class MplIPythonMode(IPythonMode):
 
         # TODO: use size from configuration
         fig = output_module.get_input('value')
-        display(fig.figInstance)
+        display(fig)
 
 class MplFigureOutput(OutputModule):
     _settings = ModuleSettings(configure_widget="vistrails.gui.modules.output_configuration:OutputModuleConfigurationWidget")

--- a/vistrails/packages/matplotlib/figure_cell.py
+++ b/vistrails/packages/matplotlib/figure_cell.py
@@ -112,12 +112,12 @@ class MplFigureCellWidget(QCellWidget):
         Update the widget contents based on the input data
         
         """
-        (fig, ) = inputPorts
-        if not self.figure or self.figure.number != fig.figInstance.number:
+        (figInstance, ) = inputPorts
+        if not self.figure or self.figure.number != figInstance.number:
             if self.layout().count() > 0:
                 self.layout().removeWidget(self.canvas)
 
-            self.figure = fig.figInstance
+            self.figure = figInstance
 
             self.canvas = FigureCanvasQTAgg(self.figure)
             self.mplToolbar = MplNavigationToolbar(self.canvas, None)

--- a/vistrails/packages/matplotlib/identifiers.py
+++ b/vistrails/packages/matplotlib/identifiers.py
@@ -44,6 +44,6 @@ from __future__ import division
 
 identifier = 'org.vistrails.vistrails.matplotlib'
 name = 'matplotlib'
-version = '1.0.5'
+version = '1.0.6'
 old_identifiers = ['edu.utah.sci.vistrails.matplotlib',
                    'org.vistrails.matplotlib.new']

--- a/vistrails/packages/matplotlib/init.py
+++ b/vistrails/packages/matplotlib/init.py
@@ -160,8 +160,10 @@ def handle_module_upgrade_request(controller, module_id, pipeline):
                     'MplFigure':
                     [(None, '1.0.0', None,
                       {'dst_port_remap': {'Script': 'addPlot'},
-                       'src_port_remap': {'FigureManager': 'self',
-                                          'File': 'file'}})],
+                       'src_port_remap': {'FigureManager': 'figure',
+                                          'File': 'file'}}),
+                     ('1.0.0', '1.0.6', None,
+                      {'src_port_remap': {'self': 'figure'}})],
                     'MplFigureCell':
                     [(None, '1.0.0', None,
                       {'dst_port_remap': {'FigureManager': 'figure'}})],


### PR DESCRIPTION
This follows up on the dont-pass-module-as-data effort.

It fixes this warning:
```
2015-07-28 11:07:49,293 WARNING:
vistrails/core/modules/vistrails_module.py, line 1724
UserWarning: A Module instance was used as data: module=MplFigure, port=self, object=<vistrails.packages.matplotlib.bases.MplFigure object at 0x7ff2db9a6410>
  UserWarning)
```