### PR TITLE
Remove NotCacheable from JobMixin

### DIFF
--- a/vistrails/core/vistrail/job.py
+++ b/vistrails/core/vistrail/job.py
@@ -54,7 +54,7 @@ import unittest
 import weakref
 
 
-class JobMixin(NotCacheable):
+class JobMixin(object):
     """ Mixin for suspendable modules.
 
     This provides the base behavior for modules that submit jobs by handling


### PR DESCRIPTION
This doesn't appear to be useful, and prevents caching of the job once it is finished.