### PR TITLE
Always register all tabledata modules

### DIFF
--- a/vistrails/packages/tabledata/__init__.py
+++ b/vistrails/packages/tabledata/__init__.py
@@ -1,3 +1,38 @@
+###############################################################################
+##
+## Copyright (C) 2014-2015, New York University.
+## Copyright (C) 2013-2014, NYU-Poly.
+## All rights reserved.
+## Contact: contact@vistrails.org
+##
+## This file is part of VisTrails.
+##
+## "Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimer.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimer in the
+##    documentation and/or other materials provided with the distribution.
+##  - Neither the name of the New York University nor the names of its
+##    contributors may be used to endorse or promote products derived from
+##    this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+## THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+## PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+## CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+## OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+## WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+## OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+## ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+##
+###############################################################################
+
 """Table data package for VisTrails.
 
 This package contains data extraction and manipulation facilities. It wraps

--- a/vistrails/packages/tabledata/common.py
+++ b/vistrails/packages/tabledata/common.py
@@ -35,17 +35,41 @@
 
 from __future__ import division
 
-try:
-    import numpy
-except ImportError: # pragma: no cover
-    numpy = None
-
+from vistrails.core.bundles.pyimport import py_import
 from vistrails.core.modules.basic_modules import List, ListType
 from vistrails.core.modules.config import ModuleSettings
 from vistrails.core.modules.output_modules import OutputModule, FileMode, \
     IPythonMode
 from vistrails.core.modules.vistrails_module import Module, ModuleError, \
     Converter
+
+
+_numpy = False
+
+def get_numpy(required=True):
+    """Tries to import numpy.
+
+    If `required` is False, don't ask again if the user already declined;
+    return None if numpy is not available.
+    If `required` is True, do ask to install, and raise ImportError if numpy
+    can't be set up.
+    """
+    global _numpy
+
+    if _numpy is False:
+        try:
+            _numpy = py_import(
+                    'numpy', {
+                        'pip': 'numpy',
+                        'linux-debian': 'python-numpy',
+                        'linux-ubuntu': 'python-numpy',
+                        'linux-fedora': 'numpy'},
+                    store_in_config=not required)
+        except ImportError:
+            _numpy = None
+    if _numpy is None and required:
+        raise ImportError("No module named numpy")
+    return _numpy
 
 
 class InternalModuleError(Exception):
@@ -77,6 +101,7 @@ class TableObject(object):
         If numeric=True, the data is returned as a numpy array if numpy is
         available, or as a list of floats.
         """
+        numpy = get_numpy(False)
         if numeric and numpy is not None:
             return numpy.array(self._columns[i], dtype=numpy.float32)
         else:

--- a/vistrails/packages/tabledata/common.py
+++ b/vistrails/packages/tabledata/common.py
@@ -1,3 +1,38 @@
+###############################################################################
+##
+## Copyright (C) 2014-2015, New York University.
+## Copyright (C) 2013-2014, NYU-Poly.
+## All rights reserved.
+## Contact: contact@vistrails.org
+##
+## This file is part of VisTrails.
+##
+## "Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimer.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimer in the
+##    documentation and/or other materials provided with the distribution.
+##  - Neither the name of the New York University nor the names of its
+##    contributors may be used to endorse or promote products derived from
+##    this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+## THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+## PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+## CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+## OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+## WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+## OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+## ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+##
+###############################################################################
+
 from __future__ import division
 
 try:

--- a/vistrails/packages/tabledata/convert/__init__.py
+++ b/vistrails/packages/tabledata/convert/__init__.py
@@ -38,14 +38,7 @@ from __future__ import division
 from vistrails.core.modules.utils import make_modules_dict
 
 from convert_dates import _modules as dates_modules
-
-try:
-    # write_numpy requires numpy
-    import numpy
-except ImportError: # pragma: no cover
-    numpy_modules = []
-else:
-    from .convert_numpy import _modules as numpy_modules
+from .convert_numpy import _modules as numpy_modules
 
 
 _modules = make_modules_dict(dates_modules, numpy_modules,

--- a/vistrails/packages/tabledata/convert/convert_numpy.py
+++ b/vistrails/packages/tabledata/convert/convert_numpy.py
@@ -35,9 +35,9 @@
 
 from __future__ import division
 
-import numpy
-
 from vistrails.core.modules.vistrails_module import Module
+
+from ..common import get_numpy
 
 
 class Reshape(Module):
@@ -50,6 +50,8 @@ class Reshape(Module):
             ('value', '(org.vistrails.vistrails.basic:List)')]
 
     def compute(self):
+        numpy = get_numpy()
+
         array = self.get_input('array')
         shape = self.get_input('shape')
 

--- a/vistrails/packages/tabledata/identifiers.py
+++ b/vistrails/packages/tabledata/identifiers.py
@@ -1,3 +1,38 @@
+###############################################################################
+##
+## Copyright (C) 2014-2015, New York University.
+## Copyright (C) 2013-2014, NYU-Poly.
+## All rights reserved.
+## Contact: contact@vistrails.org
+##
+## This file is part of VisTrails.
+##
+## "Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimer.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimer in the
+##    documentation and/or other materials provided with the distribution.
+##  - Neither the name of the New York University nor the names of its
+##    contributors may be used to endorse or promote products derived from
+##    this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+## THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+## PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+## CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+## OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+## WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+## OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+## ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+##
+###############################################################################
+
 from __future__ import division
 
 identifier = 'org.vistrails.vistrails.tabledata'

--- a/vistrails/packages/tabledata/init.py
+++ b/vistrails/packages/tabledata/init.py
@@ -1,3 +1,38 @@
+###############################################################################
+##
+## Copyright (C) 2014-2015, New York University.
+## Copyright (C) 2013-2014, NYU-Poly.
+## All rights reserved.
+## Contact: contact@vistrails.org
+##
+## This file is part of VisTrails.
+##
+## "Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimer.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimer in the
+##    documentation and/or other materials provided with the distribution.
+##  - Neither the name of the New York University nor the names of its
+##    contributors may be used to endorse or promote products derived from
+##    this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+## THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+## PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+## CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+## OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+## WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+## OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+## ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+##
+###############################################################################
+
 from __future__ import division
 
 from vistrails.core.bundles.pyimport import py_import

--- a/vistrails/packages/tabledata/init.py
+++ b/vistrails/packages/tabledata/init.py
@@ -35,19 +35,9 @@
 
 from __future__ import division
 
-from vistrails.core.bundles.pyimport import py_import
 from vistrails.core.modules.utils import make_modules_dict
 from vistrails.core.packagemanager import get_package_manager
 from vistrails.core.upgradeworkflow import UpgradeWorkflowHandler
-
-try:
-    py_import('numpy', {
-            'pip': 'numpy',
-            'linux-debian': 'python-numpy',
-            'linux-ubuntu': 'python-numpy',
-            'linux-fedora': 'numpy'})
-except ImportError: # pragma: no cover
-    pass
 
 from .common import _modules as common_modules, TableOutput
 from .convert import _modules as convert_modules

--- a/vistrails/packages/tabledata/operations.py
+++ b/vistrails/packages/tabledata/operations.py
@@ -35,15 +35,12 @@
 
 from __future__ import division
 
-try:
-    import numpy
-except ImportError: # pragma: no cover
-    numpy = None
 import re
 
 from vistrails.core.modules.vistrails_module import ModuleError
 
-from .common import TableObject, Table, choose_column, choose_columns
+from .common import get_numpy, TableObject, Table, \
+    choose_column, choose_columns
 
 # FIXME use pandas?
 
@@ -118,6 +115,7 @@ class JoinedTables(TableObject):
                     j = self.row_map[i]
                     result.append(column[j])
 
+        numpy = get_numpy(False)
         if numeric and numpy is not None:
             result = numpy.array(result, dtype=numpy.float32)
         self.column_cache[(index, numeric)] = result
@@ -427,6 +425,8 @@ class TestJoin(unittest.TestCase):
     def test_join(self):
         """Test joining tables that have column names.
         """
+        import numpy
+
         with intercept_result(JoinTables, 'value') as results:
             self.assertFalse(execute([
                     ('BuildTable', identifier, [
@@ -646,6 +646,8 @@ class TestSelect(unittest.TestCase):
     def test_numeric(self):
         """Selects using the 'less-than' condition.
         """
+        import numpy
+
         self.do_select([
                 ('float_expr', [('String', '6'),
                                 ('String', '<='),

--- a/vistrails/packages/tabledata/operations.py
+++ b/vistrails/packages/tabledata/operations.py
@@ -1,3 +1,38 @@
+###############################################################################
+##
+## Copyright (C) 2014-2015, New York University.
+## Copyright (C) 2013-2014, NYU-Poly.
+## All rights reserved.
+## Contact: contact@vistrails.org
+##
+## This file is part of VisTrails.
+##
+## "Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimer.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimer in the
+##    documentation and/or other materials provided with the distribution.
+##  - Neither the name of the New York University nor the names of its
+##    contributors may be used to endorse or promote products derived from
+##    this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+## THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+## PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+## CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+## OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+## WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+## OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+## ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+##
+###############################################################################
+
 from __future__ import division
 
 try:

--- a/vistrails/packages/tabledata/read/__init__.py
+++ b/vistrails/packages/tabledata/read/__init__.py
@@ -38,20 +38,8 @@ from __future__ import division
 from vistrails.core.modules.utils import make_modules_dict
 
 from .convert import _modules as convert_modules
-
-try:
-    # read_numpy requires numpy
-    import numpy
-except ImportError: # pragma: no cover
-    numpy_modules = []
-else:
-    from .read_numpy import _modules as numpy_modules
-
-from .read_excel import get_xlrd
-if get_xlrd():
-    from .read_excel import _modules as excel_modules
-else: # pragma: no cover
-    excel_modules = []
+from .read_excel import _modules as excel_modules
+from .read_numpy import _modules as numpy_modules
 
 from .read_csv import _modules as csv_modules
 from .read_json import _modules as json_modules

--- a/vistrails/packages/tabledata/read/read_csv.py
+++ b/vistrails/packages/tabledata/read/read_csv.py
@@ -37,12 +37,8 @@ from __future__ import division
 
 import csv
 import operator
-try:
-    import numpy
-except ImportError: # pragma: no cover
-    numpy = None
 
-from ..common import TableObject, Table, InternalModuleError
+from ..common import get_numpy, TableObject, Table, InternalModuleError
 
 
 def count_lines(fp):
@@ -128,6 +124,8 @@ class CSVTable(TableObject):
     def get_column(self, index, numeric=False):
         if (index, numeric) in self.column_cache:
             return self.column_cache[(index, numeric)]
+
+        numpy = get_numpy(False)
 
         if numeric and numpy is not None:
             result = numpy.loadtxt(

--- a/vistrails/packages/tabledata/read/read_excel.py
+++ b/vistrails/packages/tabledata/read/read_excel.py
@@ -35,15 +35,10 @@
 
 from __future__ import division
 
-try:
-    import numpy
-except ImportError: # pragma: no cover
-    numpy = None
-
 from vistrails.core.bundles.pyimport import py_import
 from vistrails.core.modules.vistrails_module import ModuleError
 
-from ..common import TableObject, Table
+from ..common import get_numpy, TableObject, Table
 
 
 def get_xlrd():
@@ -79,6 +74,8 @@ class ExcelTable(TableObject):
     def get_column(self, index, numeric=False):
         if (index, numeric) in self.column_cache:
             return self.column_cache[(index, numeric)]
+
+        numpy = get_numpy(False)
 
         result = [c.value for c in self.sheet.col(index)]
         if self.header_present:

--- a/vistrails/packages/tabledata/read/read_numpy.py
+++ b/vistrails/packages/tabledata/read/read_numpy.py
@@ -35,9 +35,9 @@
 
 from __future__ import division
 
-import numpy
-
 from vistrails.core.modules.vistrails_module import Module
+
+from ..common import get_numpy
 
 
 class NumPyArray(Module):
@@ -55,37 +55,61 @@ class NumPyArray(Module):
     """
     NPY_FMT = object()
 
-    FORMAT_MAP = dict(
-               npy = NPY_FMT,
+    FORMATS = [
+        'int8',
+        'uint8',
+        'int16',
+        'uint16',
+        'int32',
+        'uint32',
+        'int64',
+        'uint64',
+        'float32',
+        'float64',
+        'complex64',
+        'complex128',
+    ]
 
-              int8 = numpy.int8,
-             uint8 = numpy.uint8,
-             int16 = numpy.int16,
-            uint16 = numpy.uint16,
-             int32 = numpy.int32,
-            uint32 = numpy.uint32,
-             int64 = numpy.int64,
-            uint64 = numpy.uint64,
+    _format_map = None
 
-           float32 = numpy.float32,
-           float64 = numpy.float64,
+    @classmethod
+    def get_format(cls, format):
+        if cls._format_map is None:
+            numpy = get_numpy()
+            cls._format_map = dict(
+                       npy = cls.NPY_FMT,
 
-         complex64 = numpy.complex64,
-        complex128 = numpy.complex128,
-    )
+                      int8 = numpy.int8,
+                     uint8 = numpy.uint8,
+                     int16 = numpy.int16,
+                    uint16 = numpy.uint16,
+                     int32 = numpy.int32,
+                    uint32 = numpy.uint32,
+                     int64 = numpy.int64,
+                    uint64 = numpy.uint64,
+
+                   float32 = numpy.float32,
+                   float64 = numpy.float64,
+
+                 complex64 = numpy.complex64,
+                complex128 = numpy.complex128,
+            )
+        return cls._format_map[format]
 
     _input_ports = [
             ('file', '(org.vistrails.vistrails.basic:File)'),
             ('datatype', '(org.vistrails.vistrails.basic:String)',
-             {'entry_types': "['enum']", 'values': "[%r]" % FORMAT_MAP.keys()}),
+             {'entry_types': "['enum']", 'values': "[%r]" % FORMATS}),
             ('shape', '(org.vistrails.vistrails.basic:List)')]
     _output_ports = [
             ('value', '(org.vistrails.vistrails.basic:List)')]
 
     def compute(self):
+        numpy = get_numpy()
+
         filename = self.get_input('file').name
         if self.has_input('datatype'):
-            dtype = NumPyArray.FORMAT_MAP[self.get_input('datatype')]
+            dtype = NumPyArray.get_format(self.get_input('datatype'))
         else:
             if filename[-4:].lower() == '.npy':
                 dtype = self.NPY_FMT

--- a/vistrails/packages/tabledata/viewer.py
+++ b/vistrails/packages/tabledata/viewer.py
@@ -1,3 +1,38 @@
+###############################################################################
+##
+## Copyright (C) 2014-2015, New York University.
+## Copyright (C) 2013-2014, NYU-Poly.
+## All rights reserved.
+## Contact: contact@vistrails.org
+##
+## This file is part of VisTrails.
+##
+## "Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimer.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimer in the
+##    documentation and/or other materials provided with the distribution.
+##  - Neither the name of the New York University nor the names of its
+##    contributors may be used to endorse or promote products derived from
+##    this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+## THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+## PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+## CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+## OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+## WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+## OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+## ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+##
+###############################################################################
+
 from __future__ import division
 
 import os

--- a/vistrails/packages/tabledata/widgets.py
+++ b/vistrails/packages/tabledata/widgets.py
@@ -1,3 +1,38 @@
+###############################################################################
+##
+## Copyright (C) 2014-2015, New York University.
+## Copyright (C) 2013-2014, NYU-Poly.
+## All rights reserved.
+## Contact: contact@vistrails.org
+##
+## This file is part of VisTrails.
+##
+## "Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimer.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimer in the
+##    documentation and/or other materials provided with the distribution.
+##  - Neither the name of the New York University nor the names of its
+##    contributors may be used to endorse or promote products derived from
+##    this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+## THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+## PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+## CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+## OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+## WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+## OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+## ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+##
+###############################################################################
+
 from __future__ import division
 
 from PyQt4 import QtCore, QtGui

--- a/vistrails/packages/tabledata/write/__init__.py
+++ b/vistrails/packages/tabledata/write/__init__.py
@@ -37,21 +37,9 @@ from __future__ import division
 
 from vistrails.core.modules.utils import make_modules_dict
 
-try:
-    # write_numpy requires numpy
-    import numpy
-except ImportError: # pragma: no cover
-    numpy_modules = []
-else:
-    from .write_numpy import _modules as numpy_modules
-
-from .write_excel import get_xlwt
-if get_xlwt():
-    from .write_excel import _modules as excel_modules
-else: # pragma: no cover
-    excel_modules = []
-
 from .write_csv import _modules as csv_modules
+from .write_excel import _modules as excel_modules
+from .write_numpy import _modules as numpy_modules
 
 
 _modules = make_modules_dict(numpy_modules, csv_modules, excel_modules,
@@ -125,10 +113,16 @@ class BaseWriteTestCase(object):
         self.assertEqual(results[0], ['a', '2', 'c'])
 
 
-@unittest.skipIf(get_xlwt() is None, "xlwt not available")
 class ExcelWriteTestCase(unittest.TestCase, BaseWriteTestCase):
     WRITER_MODULE = 'write|WriteExcelSpreadsheet'
     READER_MODULE = 'read|ExcelSpreadsheet'
+
+    @classmethod
+    def setUpClass(cls):
+        from .write_excel import get_xlwt
+
+        if get_xlwt() is None:
+            raise unittest.SkipTest("xlwt not available")
 
 
 class CSVWriteTestCase(unittest.TestCase, BaseWriteTestCase):

--- a/vistrails/packages/tabledata/write/write_numpy.py
+++ b/vistrails/packages/tabledata/write/write_numpy.py
@@ -1,9 +1,8 @@
 from __future__ import division
 
-import numpy
-
 from vistrails.core.modules.vistrails_module import Module
 
+from ..common import get_numpy
 from ..read.read_numpy import NumPyArray
 
 
@@ -19,14 +18,16 @@ class WriteNumPy(Module):
             ('array', '(org.vistrails.vistrails.basic:List)'),
             ('datatype', '(org.vistrails.vistrails.basic:String)',
              {'entry_types': "['enum']",
-              'values': "[%r]" % NumPyArray.FORMAT_MAP.keys()})]
+              'values': "[%r]" % NumPyArray.FORMATS})]
     _output_ports = [('file', '(org.vistrails.vistrails.basic:File)')]
 
     def compute(self):
+        numpy = get_numpy()
+
         array = self.get_input('array')
         if not isinstance(array, numpy.ndarray):
             array = numpy.array(array)
-        dtype = NumPyArray.FORMAT_MAP[self.get_input('datatype')]
+        dtype = NumPyArray.get_format(self.get_input('datatype'))
 
         if dtype is NumPyArray.NPY_FMT:
             fileobj = self.interpreter.filePool.create_file(suffix='.npy')
@@ -78,6 +79,7 @@ class WriteNumpyTestCase(unittest.TestCase):
     def test_npy_numpy(self):
         """Uses WriteNumPy to write an array in .NPY format.
         """
+        import numpy
         from vistrails.tests.utils import execute, intercept_result
         from ..identifiers import identifier
         with intercept_result(WriteNumPy, 'file') as results:


### PR DESCRIPTION
No longer check for numpy/xlrd/xlwt before adding modules, add them and check for lib when module is used (possibly triggering bundle installation logic).

Should go in v2.2?