### PR TITLE
Improve interpreter and cache

### DIFF
--- a/vistrails/core/modules/basic_modules.py
+++ b/vistrails/core/modules/basic_modules.py
@@ -802,12 +802,7 @@ class Tuple(Module):
 
     def __init__(self):
         Module.__init__(self)
-        self.input_ports_order = []
         self.values = tuple()
-
-    def transfer_attrs(self, module):
-        Module.transfer_attrs(self, module)
-        self.input_ports_order = [p.name for p in module.input_port_specs]
 
     def compute(self):
         values = tuple([self.get_input(p)
@@ -823,16 +818,6 @@ class Untuple(Module):
 
     _settings = ModuleSettings(configure_widget=
         "vistrails.gui.modules.tuple_configuration:UntupleConfigurationWidget")
-
-    def __init__(self):
-        Module.__init__(self)
-        self.output_ports_order = []
-
-    def transfer_attrs(self, module):
-        Module.transfer_attrs(self, module)
-        self.output_ports_order = [p.name for p in module.output_port_specs]
-        # output_ports are reversed for display purposes...
-        self.output_ports_order.reverse()
 
     def compute(self):
         if self.has_input("tuple"):
@@ -900,14 +885,6 @@ class List(Constant):
     _output_ports = [OPort("value", "List")]
 
     default_value = []
-
-    def __init__(self):
-        Constant.__init__(self)
-        self.input_ports_order = []
-
-    def transfer_attrs(self, module):
-        Module.transfer_attrs(self, module)
-        self.input_ports_order = [p.name for p in module.input_port_specs]
 
     @staticmethod
     def validate(x):
@@ -1010,16 +987,6 @@ class Unpickle(Module):
 ##############################################################################
 
 class CodeRunnerMixin(object):
-    def __init__(self):
-        self.output_ports_order = []
-        super(CodeRunnerMixin, self).__init__()
-
-    def transfer_attrs(self, module):
-        Module.transfer_attrs(self, module)
-        self.output_ports_order = [p.name for p in module.output_port_specs]
-        # output_ports are reversed for display purposes...
-        self.output_ports_order.reverse()
-
     def run_code(self, code_str,
                  use_input=False,
                  use_output=False):

--- a/vistrails/core/modules/sub_module.py
+++ b/vistrails/core/modules/sub_module.py
@@ -343,6 +343,7 @@ class Abstraction(Group):
                                hide_descriptor=True)
 
     def transfer_attrs(self, module):
+        # Skip Group#transfer_attrs()
         Module.transfer_attrs(self, module)
 
     # the compute method is inherited from Group!

--- a/vistrails/core/modules/vistrails_module.py
+++ b/vistrails/core/modules/vistrails_module.py
@@ -328,10 +328,14 @@ class Module(object):
         for cp in module.control_parameters:
             self.control_params[cp.name] = cp.value
 
-        self.input_specs = dict((p.name, p) for p in module.destinationPorts())
-        self.output_specs = dict((p.name, p) for p in module.sourcePorts())
-        self.input_specs_order = [p.name for p in module.destinationPorts()]
-        self.output_specs_order = [p.name for p in module.sourcePorts()]
+        self.input_specs = dict((p.name, p) for p in module.destinationPorts())  # rename this (check vtk)
+        self.output_specs = dict((p.name, p) for p in module.sourcePorts())  # rename this (check vtk)
+        self.input_specs_order = [p.name for p in module.destinationPorts()]  # remove, replace with input_specs
+        self.output_specs_order = [p.name for p in module.sourcePorts()]  # remove, replace with output_specs
+
+        # These should probably have another name, but compatibility...
+        self.input_ports_order = [p.name for p in module.input_port_specs]
+        self.output_ports_order = [p.name for p in module.output_port_specs]
 
     def __copy__(self):
         """Makes a copy of the input/output ports on shallow copy.

--- a/vistrails/packages/tabledata/common.py
+++ b/vistrails/packages/tabledata/common.py
@@ -273,14 +273,6 @@ class BuildTable(Module):
             'vistrails.packages.tabledata.widgets:BuildTableWidget')
     _output_ports = [('value', Table)]
 
-    def __init__(self):
-        Module.__init__(self)
-        self.input_ports_order = []
-
-    def transfer_attrs(self, module):
-        Module.transfer_attrs(self, module)
-        self.input_ports_order = [p.name for p in module.input_port_specs]
-
     def compute(self):
         items = None
         if self.input_ports_order: # pragma: no branch


### PR DESCRIPTION
Most of this is directions on paper right now, I'll try to add details here.

The idea is to move away from the current caching and execution model (instantiate every module in persistent pipeline according to signatures, recurse inside the Module themselves) to an external model that drives the execution as needed (this would allow #1060).

Modules would become very dumb execution functions with metadata for the interpreter (we can make them functions instead of classes, I'm thinking about versioning the package API as well for futureproofing).

The multiple levels of interpreters used for groups and subworkflows would disappear, modules would just be able to add more modules to the workflow during execution (which would unify with looping); should address #765. Streaming needs to be built into this, removing the need for passing around generators.

The cache would be used during the execution itself, which would allow more possibility than simply "cacheable" or "notcacheable". A module would output a cache signature along with its output, which would allow modules to be rechecked but still caching its downstream, or different modules to hit the same cache key (e.g. the DownloadFile module could just use a SHA-1 of the file as the cache key). Caching to disk could also be added here in time (#640).

```
from VT workflow

mark depth, insert depth bumping points (x -> [x])
(split workflow for execution on multiple targets)

for module in sink:
    exec(module)

exec(module):
    for upstream_module:
        exec(upstream_module)

    compute_sig(module_id + upstream)
    check cache
    execute (might submit more modules for execution, e.g. controlflow or group)
    record provenance
    add result to cache
```

TODO: more details, more code