### PR TITLE
Collect anonymous usage statistics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ scikit-learn
 nose
 file_archive>=0.6
 tej>=0.3
+usagestats>=0.3

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ requirements = [
     'certifi',
     'backports.ssl_match_hostname',
     'file_archive>=0.6',
+    'requests',
     'usagestats>=0.3',
     'xlrd',
     'xlwt',

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ requirements = [
     'certifi',
     'backports.ssl_match_hostname',
     'file_archive>=0.6',
+    'usagestats>=0.3',
     'xlrd',
     'xlwt',
 ]

--- a/vistrails/core/application.py
+++ b/vistrails/core/application.py
@@ -54,6 +54,7 @@ import vistrails.core.interpreter.cached
 import vistrails.core.interpreter.default
 from vistrails.core.modules.module_registry import ModuleRegistry
 from vistrails.core.packagemanager import PackageManager
+from vistrails.core import reportusage
 import vistrails.core.requirements
 from vistrails.core.startup import VistrailsStartup
 from vistrails.core.thumbnails import ThumbnailCache
@@ -170,6 +171,9 @@ class VistrailsApplicationInterface(object):
 
         self.package_manager = PackageManager(self.registry,
                                               self.startup)
+
+        if reportusage.update_config(self.temp_configuration):
+            self.temp_configuration.batch = True
 
     def check_all_requirements(self):
         # check scipy

--- a/vistrails/core/application.py
+++ b/vistrails/core/application.py
@@ -54,7 +54,6 @@ import vistrails.core.interpreter.cached
 import vistrails.core.interpreter.default
 from vistrails.core.modules.module_registry import ModuleRegistry
 from vistrails.core.packagemanager import PackageManager
-from vistrails.core.reportusage import record_vistrail
 import vistrails.core.requirements
 from vistrails.core.startup import VistrailsStartup
 from vistrails.core.thumbnails import ThumbnailCache
@@ -410,7 +409,6 @@ class VistrailsApplicationInterface(object):
                 loaded_objs = vistrails.core.db.io.load_vistrail(locator, is_abstraction)
                 controller = self.add_vistrail(loaded_objs[0], locator, 
                                                *loaded_objs[1:])
-                record_vistrail('open', controller)
                 if locator.is_untitled():
                     return controller
                 controller.is_abstraction = is_abstraction

--- a/vistrails/core/application.py
+++ b/vistrails/core/application.py
@@ -54,6 +54,7 @@ import vistrails.core.interpreter.cached
 import vistrails.core.interpreter.default
 from vistrails.core.modules.module_registry import ModuleRegistry
 from vistrails.core.packagemanager import PackageManager
+from vistrails.core.reportusage import record_vistrail
 import vistrails.core.requirements
 from vistrails.core.startup import VistrailsStartup
 from vistrails.core.thumbnails import ThumbnailCache
@@ -409,6 +410,7 @@ class VistrailsApplicationInterface(object):
                 loaded_objs = vistrails.core.db.io.load_vistrail(locator, is_abstraction)
                 controller = self.add_vistrail(loaded_objs[0], locator, 
                                                *loaded_objs[1:])
+                record_vistrail('open', controller)
                 if locator.is_untitled():
                     return controller
                 controller.is_abstraction = is_abstraction

--- a/vistrails/core/configuration.py
+++ b/vistrails/core/configuration.py
@@ -124,6 +124,7 @@ showScrollbars: Show scrollbars on the version tree and workflow canvases
 showSplash: Show VisTrails splash screen during startup
 showSpreadsheetOnly: Hides the VisTrails main window
 showVariantErrors: Show error when variant input value doesn't match type during execution
+showVistrailsNews: Show news from VisTrails (once per message)
 showWindow: Show the main window
 singleInstance: Do not allow more than one instance of VisTrails to run at once
 spreadsheetDumpCells: Defines the location for generated cells
@@ -471,6 +472,11 @@ showVariantErrors: Boolean
     Alert the user if the value along a connection coming from a
     Variant output doesn't match the input port.
 
+showVistrailsNews: Boolean
+
+    Show news from VisTrails on startup. Each message will only be displayed
+    once.
+
 showWindow: Boolean
 
     Show the main VisTrails window.
@@ -708,7 +714,8 @@ base_config = {
                                               "Debug Messages"}}),
      ConfigField('reportUsage', -1, int, ConfigType.INTERNAL,
                  widget_type="usagestats",
-                 widget_options={'label': 'Anonymous usage reporting'})],
+                 widget_options={'label': 'Anonymous usage reporting'}),
+     ConfigField('showVistrailsNews', True, bool, ConfigType.SHOW_HIDE)],
     "Startup":
     [ConfigField('maximizeWindows', False, bool, ConfigType.ON_OFF),
      ConfigField('multiHeads', False, bool, ConfigType.ON_OFF),
@@ -787,7 +794,8 @@ base_config = {
      ConfigField('rootDirectory', None, ConfigPath, ConfigType.INTERNAL),
      ConfigField('developerDebugger', False, bool, ConfigType.INTERNAL),
      ConfigField('dontUnloadModules', False, bool, ConfigType.INTERNAL),
-     ConfigField('bundleDeclinedList', '', str, ConfigType.INTERNAL)],
+     ConfigField('bundleDeclinedList', '', str, ConfigType.INTERNAL),
+     ConfigField('lastShownNews', '', str, ConfigType.INTERNAL)],
     "Jobs":
     [ConfigField('jobCheckInterval', 600, int),
      ConfigField('jobAutorun', False, bool),

--- a/vistrails/core/configuration.py
+++ b/vistrails/core/configuration.py
@@ -104,6 +104,8 @@ packageDir: System packages directory
 parameterExploration: Run parameter exploration instead of workflow
 parameters: List of parameters to use when running workflow
 port: The port for the database to load the vistrail from
+enableUsage: Enable sending anonymous usage statistics
+disableUsage: Disable sending anonymous usage statistics
 repositoryHTTPURL: Remote package repository URL
 repositoryLocalPath: Local package repository directory
 rootDirectory: Directory that contains the VisTrails source code
@@ -368,6 +370,14 @@ pythonPrompt: Boolean
 recentVistrailList: String
 
     Storage for recent vistrails. Users should not edit.
+
+enableUsage: Boolean
+
+    Enable sending anonymous usage statistics
+
+disableUsage: Boolean
+
+    Disable sending anonymous usage statistics
 
 repositoryHTTPURL: URL
 
@@ -654,7 +664,9 @@ base_config = {
      ConfigField('showWindow', True, bool, ConfigType.COMMAND_LINE_FLAG),
      ConfigField("outputVersionTree", False, bool, ConfigType.COMMAND_LINE_FLAG),
      ConfigField("outputPipelineGraph", False, bool, ConfigType.COMMAND_LINE_FLAG),
-     ConfigField("graphsAsPdf", True, bool, ConfigType.COMMAND_LINE_FLAG)],
+     ConfigField("graphsAsPdf", True, bool, ConfigType.COMMAND_LINE_FLAG),
+     ConfigField('enableUsage', False, bool, ConfigType.COMMAND_LINE_FLAG),
+     ConfigField('disableUsage', False, bool, ConfigType.COMMAND_LINE_FLAG)],
     "Database":
     [ConfigField("host", None, ConfigURL, ConfigType.COMMAND_LINE),
      ConfigField("port", None, int, ConfigType.COMMAND_LINE),

--- a/vistrails/core/configuration.py
+++ b/vistrails/core/configuration.py
@@ -104,6 +104,7 @@ packageDir: System packages directory
 parameterExploration: Run parameter exploration instead of workflow
 parameters: List of parameters to use when running workflow
 port: The port for the database to load the vistrail from
+reportUsage: Report anonymous usage statistics to the developers
 enableUsage: Enable sending anonymous usage statistics
 disableUsage: Disable sending anonymous usage statistics
 repositoryHTTPURL: Remote package repository URL
@@ -370,6 +371,10 @@ pythonPrompt: Boolean
 recentVistrailList: String
 
     Storage for recent vistrails. Users should not edit.
+
+reportUsage: Integer
+
+    Report anonymous usage statistics to the developers
 
 enableUsage: Boolean
 
@@ -700,7 +705,10 @@ base_config = {
                                  "remap": {0: "Critical Errors Only",
                                            1: "Critical Errors and Warnings",
                                            2: "Errors, Warnings, and "
-                                              "Debug Messages"}})],
+                                              "Debug Messages"}}),
+     ConfigField('reportUsage', -1, int, ConfigType.INTERNAL,
+                 widget_type="usagestats",
+                 widget_options={'label': 'Anonymous usage reporting'})],
     "Startup":
     [ConfigField('maximizeWindows', False, bool, ConfigType.ON_OFF),
      ConfigField('multiHeads', False, bool, ConfigType.ON_OFF),

--- a/vistrails/core/interpreter/cached.py
+++ b/vistrails/core/interpreter/cached.py
@@ -41,6 +41,8 @@ import copy
 import gc
 import cPickle as pickle
 
+import time
+
 from vistrails.core.common import InstanceObject, VistrailsInternalError
 from vistrails.core.data_structures.bijectivedict import Bidict
 from vistrails.core import debug
@@ -54,6 +56,7 @@ from vistrails.core.modules.module_registry import get_module_registry
 from vistrails.core.modules.vistrails_module import ModuleBreakpoint, \
     ModuleConnector, ModuleError, ModuleErrors, ModuleHadError, \
     ModuleSuspended, ModuleWasSuspended
+from vistrails.core.reportusage import record_usage
 from vistrails.core.utils import DummyView
 import vistrails.core.system
 import vistrails.core.vistrail.pipeline
@@ -553,6 +556,8 @@ class CachedInterpreter(vistrails.core.interpreter.base.BaseInterpreter):
             if stop_on_error or abort:
                 break
 
+        if Generator.generators:
+            record_usage(generators=len(Generator.generators))
         # execute all generators until inputs are exhausted
         # this makes sure branching and multiple sinks are executed correctly
         if not logging_obj.errors and not logging_obj.suspended and \
@@ -722,6 +727,7 @@ class CachedInterpreter(vistrails.core.interpreter.base.BaseInterpreter):
                                          'to execute: %s' % kwargs)
         self.clean_non_cacheable_modules()
 
+        record_usage(execute=True)
 
 #         if controller is not None:
 #             vistrail = controller.vistrail
@@ -736,6 +742,7 @@ class CachedInterpreter(vistrails.core.interpreter.base.BaseInterpreter):
         else:
             vistrail = None
 
+        time_start = time.time()
         logger = logger.start_workflow_execution(
                 parent_exec,
                 vistrail, pipeline, current_version)
@@ -754,16 +761,21 @@ class CachedInterpreter(vistrails.core.interpreter.base.BaseInterpreter):
             for (i, error) in errors.iteritems():
                 view.set_module_error(i, error.msg, error.errorTrace)
         self.finalize_pipeline(pipeline, *(res[:-1]), **new_kwargs)
+        time_end = time.time()
 
         result = InstanceObject(objects=res[1],
-                              errors=res[2],
-                              executed=res[3],
-                              suspended=res[4],
-                              parameter_changes=res[6],
-                              modules_added=modules_added,
-                              conns_added=conns_added)
+                                errors=res[2],
+                                executed=res[3],
+                                suspended=res[4],
+                                parameter_changes=res[6],
+                                modules_added=modules_added,
+                                conns_added=conns_added)
 
         logger.finish_workflow_execution(result.errors, suspended=result.suspended)
+
+        record_usage(time=time_end - time_start, modules=len(res[1]),
+                     errors=len(res[2]), executed=len(res[3]),
+                     suspended=len(res[4]))
 
         return result
 

--- a/vistrails/core/modules/package.py
+++ b/vistrails/core/modules/package.py
@@ -47,6 +47,7 @@ from vistrails.core import debug
 from vistrails.core import get_vistrails_application
 from vistrails.core.configuration import get_vistrails_configuration
 from vistrails.core.modules.module_descriptor import ModuleDescriptor
+from vistrails.core.reportusage import record_usage
 from vistrails.core.utils import versions_increasing, VistrailsInternalError
 from vistrails.db.domain import DBPackage
 
@@ -413,6 +414,7 @@ class Package(DBPackage):
 
         self.set_properties()
         self.do_load_configuration()
+        record_usage(loaded_package='%s %s' % (self.identifier, self.version))
 
     def initialize(self):
         if not self._loaded:

--- a/vistrails/core/query/combined.py
+++ b/vistrails/core/query/combined.py
@@ -35,6 +35,8 @@
 ###############################################################################
 from __future__ import division
 
+from vistrails.core import reportusage
+
 from version import SearchCompiler
 from visual import VisualQuery
 
@@ -46,6 +48,8 @@ class CombinedSearch(VisualQuery):
         self.use_regex = use_regex
 
     def run(self, controller, name):
+        if self.search_str:
+            reportusage.record_feature('query', controller)
         VisualQuery.run(self, controller, name)
         compiler = SearchCompiler(self.search_str, self.use_regex)
         self.search_stmt = compiler.searchStmt

--- a/vistrails/core/query/visual.py
+++ b/vistrails/core/query/visual.py
@@ -37,6 +37,7 @@ from __future__ import division
 
 from vistrails.core import query
 from vistrails.core.modules.module_registry import get_module_registry
+from vistrails.core import reportusage
 from vistrails.core.utils import append_to_dict_of_lists
 import copy
 import re
@@ -88,6 +89,7 @@ class VisualQuery(query.Query):
             template_ids = nextTemplateIds
 
     def run(self, controller, name):
+        reportusage.record_feature('visualquery', controller)
         result = []
         self.tupleLength = 2
         for version in self.versions_to_check:

--- a/vistrails/core/reportusage.py
+++ b/vistrails/core/reportusage.py
@@ -142,6 +142,19 @@ def submit_usage_report(**kwargs):
     """Submits the current usage report to the usagestats server.
     """
     debug.debug("submit_usage_report %r" % (kwargs,))
+
+    for pkg in ('numpy', 'scipy', 'matplotlib'):
+        try:
+            pkg_o = __import__(pkg, globals(), locals())
+            usage_report.note({pkg: getattr(pkg_o, '__version__', '')})
+        except ImportError:
+            pass
+    try:
+        import vtk
+        usage_report.note({'vtk': vtk.vtkVersion().GetVTKVersion()})
+    except ImportError:
+        pass
+
     usage_report.submit(kwargs,
                         usagestats.OPERATING_SYSTEM,
                         usagestats.SESSION_TIME,

--- a/vistrails/core/reportusage.py
+++ b/vistrails/core/reportusage.py
@@ -1,0 +1,135 @@
+##############################################################################
+##
+## Copyright (C) 2014-2016, New York University.
+## Copyright (C) 2011-2014, NYU-Poly.
+## Copyright (C) 2006-2011, University of Utah.
+## All rights reserved.
+## Contact: contact@vistrails.org
+##
+## This file is part of VisTrails.
+##
+## "Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimer.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimer in the
+##    documentation and/or other materials provided with the distribution.
+##  - Neither the name of the New York University nor the names of its
+##    contributors may be used to endorse or promote products derived from
+##    this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+## THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+## PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+## CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+## EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+## PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+## OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+## WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+## OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+## ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+##
+###############################################################################
+
+"""Configuration variables for controlling specific things in VisTrails.
+"""
+
+from __future__ import division
+
+import atexit
+import os
+import tempfile
+import usagestats
+
+from vistrails.core import debug
+from vistrails.core.system import vistrails_version
+
+
+usage_report = None
+
+
+def setup_usage_report():
+    """Sets up the usagestats module.
+    """
+    global usage_report
+
+    # Unpack CA certificate
+    fd, certificate_file = tempfile.mkstemp(prefix='vistrails_stats_ca_',
+                                            suffix='.pem')
+    with open(certificate_file, 'wb') as fp:
+        fp.write(_ca_certificate)
+    os.close(fd)
+    atexit.register(os.remove, certificate_file)
+
+    usage_report = usagestats.Stats(
+        '~/.vistrails/usage_stats',
+        usagestats.Prompt(
+            "\nUploading usage statistics is currently disabled\n"
+            "Please help us by providing anonymous usage statistics; "
+            "you can enable this\neither from the GUI or by using "
+            "--enable-usage-stats\n"
+            "If you do not want to see this message again, you can disable "
+            "it from the GUI or with --disable-usage-stats\n"
+            "Nothing will be uploaded before you opt in.\n"),
+        'https://reprozip-stats.poly.edu/',
+        version='VisTrails %s' % vistrails_version(),
+        unique_user_id=True,
+        env_var='VISTRAILS_USAGE_STATS',
+        ssl_verify=certificate_file)
+
+    cwd = os.getcwd()
+    record_usage(cwd_spaces=b' ' in cwd)
+    try:
+        cwd.decode('ascii')
+    except UnicodeDecodeError:
+        record_usage(cwd_ascii=False)
+    else:
+        record_usage(cwd_ascii=True)
+
+
+def record_usage(**kwargs):
+    """Records some info in the current usage report.
+    """
+    if usage_report is not None:
+        debug.debug("record_usage %r" % (kwargs,))
+        usage_report.note(kwargs)
+
+
+def submit_usage_report(**kwargs):
+    """Submits the current usage report to the usagestats server.
+    """
+    debug.debug("submit_usage_report %r" % (kwargs,))
+    usage_report.submit(kwargs,
+                        usagestats.OPERATING_SYSTEM,
+                        usagestats.SESSION_TIME,
+                        usagestats.PYTHON_VERSION)
+
+
+_ca_certificate = b'''\
+-----BEGIN CERTIFICATE-----
+MIIDzzCCAregAwIBAgIJAMmlcDnTidBEMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV
+BAYTAlVTMREwDwYDVQQIDAhOZXcgWW9yazERMA8GA1UEBwwITmV3IFlvcmsxDDAK
+BgNVBAoMA05ZVTERMA8GA1UEAwwIUmVwcm9aaXAxKDAmBgkqhkiG9w0BCQEWGXJl
+cHJvemlwLWRldkB2Z2MucG9seS5lZHUwHhcNMTQxMTA3MDUxOTA5WhcNMjQxMTA0
+MDUxOTA5WjB+MQswCQYDVQQGEwJVUzERMA8GA1UECAwITmV3IFlvcmsxETAPBgNV
+BAcMCE5ldyBZb3JrMQwwCgYDVQQKDANOWVUxETAPBgNVBAMMCFJlcHJvWmlwMSgw
+JgYJKoZIhvcNAQkBFhlyZXByb3ppcC1kZXZAdmdjLnBvbHkuZWR1MIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1fuTW2snrVji51vGVl9hXAAZbNJ+dxG+
+/LOOxZrF2f1RRNy8YWpeCfGbsZqiIEjorBv8lvdd9P+tD3M5sh9L0zQPU9dFvDb+
+OOrV0jx59hbK3QcCQju3YFuAtD1lu8TBIPgGEab0eJhLVIX+XU5cYXrfoBmwCpN/
+1wXWkUhN91ZVMA0ylATAxTpnoNuMKzfTxT8pyOWajiTskYkKmVBAxgYJQe1YDFA8
+fglBNkQuHqP8jgYAniEBCAPZRMMq8WpOtyFx+L9LX9/WcHtAQyDPPb9M81KKgPQq
+urtCqtuDKxuqcX9zg4/O8l4nZ50pwaJjbH4kMW/wnLzTPvzZCPtJYQIDAQABo1Aw
+TjAdBgNVHQ4EFgQUJjhDDOup4P0cdrAVq1F9ap3yTj8wHwYDVR0jBBgwFoAUJjhD
+DOup4P0cdrAVq1F9ap3yTj8wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
+AQEAeKpTiy2WYPqevHseTCJDIL44zghDJ9w5JmECOhFgPXR9Hl5Nh9S1j4qHBs4G
+cn8d1p2+8tgcJpNAysjuSl4/MM6hQNecW0QVqvJDQGPn33bruMB4DYRT5du1Zpz1
+YIKRjGU7Of3CycOCbaT50VZHhEd5GS2Lvg41ngxtsE8JKnvPuim92dnCutD0beV+
+4TEvoleIi/K4AZWIaekIyqazd0c7eQjgSclNGgePcdbaxIo0u6tmdTYk3RNzo99t
+DCfXxuMMg3wo5pbqG+MvTdECaLwt14zWU259z8JX0BoeVG32kHlt2eUpm5PCfxqc
+dYuwZmAXksp0T0cWo0DnjJKRGQ==
+-----END CERTIFICATE-----
+'''

--- a/vistrails/core/reportusage.py
+++ b/vistrails/core/reportusage.py
@@ -40,7 +40,9 @@
 from __future__ import division
 
 import atexit
+import json
 import os
+import requests
 import tempfile
 import usagestats
 import weakref
@@ -57,13 +59,7 @@ def setup_usage_report():
     """
     global usage_report
 
-    # Unpack CA certificate
-    fd, certificate_file = tempfile.mkstemp(prefix='vistrails_stats_ca_',
-                                            suffix='.pem')
-    with open(certificate_file, 'wb') as fp:
-        fp.write(_ca_certificate)
-    os.close(fd)
-    atexit.register(os.remove, certificate_file)
+    certificate_file = get_ca_certificate()
 
     usage_report = usagestats.Stats(
         '~/.vistrails/usage_stats',
@@ -188,6 +184,88 @@ def submit_usage_report(**kwargs):
                         usagestats.OPERATING_SYSTEM,
                         usagestats.SESSION_TIME,
                         usagestats.PYTHON_VERSION)
+
+
+_server_news = None
+
+
+def get_server_news():
+    global _server_news
+
+    if _server_news is not None:
+        return _server_news
+
+    dot_vistrails = os.path.expanduser('~/.vistrails')
+    if not os.path.exists(dot_vistrails):
+        os.mkdir(dot_vistrails)
+
+    file_name = os.path.join(dot_vistrails, 'server_news.json')
+    file_exists = os.path.exists(file_name)
+
+    try:
+        resp = requests.get(
+            'https://reprozip-stats.poly.edu/vistrails_news/%s' %
+            vistrails_version(),
+            timeout=2 if file_exists else 10,
+            stream=True, verify=get_ca_certificate())
+        resp.raise_for_status()
+        if resp.status_code == 304:
+            raise requests.HTTPError(
+                '304 File is up to date, no data returned',
+                response=resp)
+    except requests.RequestException, e:
+        if not e.response or e.response.code != 304:
+            debug.warning("Can't download server news", e)
+    else:
+        try:
+            with open(file_name, 'wb') as f:
+                for chunk in resp.iter_content(4096):
+                    f.write(chunk)
+            resp.close()
+        except Exception, e:
+            try:
+                os.remove(file_name)
+            except OSError:
+                pass
+            raise e
+        debug.log("Downloaded server news")
+
+    if os.path.exists(file_name):
+        with open(file_name, 'r') as f:
+            _server_news = json.load(f)
+    else:
+        _server_news = _default_news
+
+    return _server_news
+
+
+def get_ca_certificate():
+    fd, certificate_file = tempfile.mkstemp(prefix='vistrails_stats_ca_',
+                                            suffix='.pem')
+    with open(certificate_file, 'wb') as fp:
+        fp.write(_ca_certificate)
+    os.close(fd)
+    atexit.register(os.remove, certificate_file)
+    return certificate_file
+
+
+_default_news = {
+    'version': '20160304',
+    'news_html':
+        u"<p>We are conducting a survey of VisTrails users. "
+        u"<a href=\"http://www.vistrails.org/\" target=\"_blank\">If you have "
+        u"a minute, please consider helping us by visiting this page.</a></p>",
+    'usage_report_prompt_html':
+        u"<p>Please help us by reporting anonymous statistics about how you "
+        u"use VisTrails.</p><p>We would like to collect high-level details "
+        u"like which packages you use, which features, the size of your "
+        u"workflows and version trees, ... This information is reported "
+        u"anonymously and will only be used by the VisTrails team, to help "
+        u"guide our efforts.</p>"
+        u"<p><a href=\"http://www.vistrails.org/\" target=\"_blank\">We are "
+        u"also conducting a survey of VisTrails users. If you have a minute, "
+        u"please consider helping us by visiting this page.</a></p>",
+}
 
 
 _ca_certificate = b'''\

--- a/vistrails/core/reportusage.py
+++ b/vistrails/core/reportusage.py
@@ -43,6 +43,7 @@ import atexit
 import os
 import tempfile
 import usagestats
+import weakref
 
 from vistrails.core import debug
 from vistrails.core.system import vistrails_version
@@ -98,6 +99,9 @@ def record_usage(**kwargs):
         usage_report.note(kwargs)
 
 
+saved_vistrails = weakref.WeakValueDictionary()
+
+
 def record_vistrail(what, vistrail):
     """Record info about a vistrail we used.
     """
@@ -110,6 +114,19 @@ def record_vistrail(what, vistrail):
 
     if isinstance(vistrail, VistrailController):
         vistrail = vistrail.vistrail
+
+    if what == 'save':
+        # Don't report now, but mark it for reporting when it gets closed
+        saved_vistrails[id(vistrail)] = vistrail
+        return
+    elif what == 'close':
+        i = id(vistrail)
+        if i in saved_vistrails:
+            del saved_vistrails[i]
+            what = 'saved_close'
+        else:
+            return
+
     if isinstance(vistrail, Vistrail):
         upgrade_from = set()
         upgrade_to = set()

--- a/vistrails/core/reportusage.py
+++ b/vistrails/core/reportusage.py
@@ -157,13 +157,30 @@ def record_vistrail(what, vistrail):
             usage_report.note({'in_examples_dir':
                 os.path.realpath(vistrail.locator._name).startswith(
                     os.path.realpath(vistrails_examples_directory()))})
+        nb_modules = 0
+        nb_groups = 0
+        nb_abstractions = 0
+        for action in vistrail.actions:
+            if action.id in upgrade_to or action.description == "Upgrade":
+                continue
+            for operation in action.operations:
+                if operation.vtType == 'add' or operation.vtType == 'change':
+                    if operation.what == 'module':
+                        nb_modules += 1
+                        if operation.data.is_group():
+                            nb_groups += 1
+                        elif operation.data.is_abstraction():
+                            nb_abstractions += 1
         usage_report.note(dict(use_vistrail=what,
                                nb_versions=len(vistrail.actionMap),
                                nb_tags=len(vistrail.tags),
                                nb_notes=nb_notes,
                                nb_paramexplorations=nb_paramexplorations,
                                nb_upgrades=nb_upgrades,
-                               nb_variables=len(vistrail.vistrail_variables)))
+                               nb_variables=len(vistrail.vistrail_variables),
+                               nb_modules=nb_modules,
+                               nb_groups=nb_groups,
+                               nb_abstractions=nb_abstractions))
         for feature in features_for_vistrails.pop(id(vistrail), ()):
             usage_report.note({'feature_for_vistrail': feature})
     elif isinstance(vistrail, Pipeline):

--- a/vistrails/core/reportusage.py
+++ b/vistrails/core/reportusage.py
@@ -91,6 +91,18 @@ def setup_usage_report():
         record_usage(cwd_ascii=True)
 
 
+def update_config(configuration):
+    if getattr(configuration, 'enableUsage', False):
+        usage_report.enable_reporting()
+        configuration.reportUsage = 1
+        return True
+    elif getattr(configuration, 'disableUsage', False):
+        usage_report.disable_reporting()
+        configuration.reportUsage = 0
+        return True
+    return False
+
+
 def record_usage(**kwargs):
     """Records some info in the current usage report.
     """

--- a/vistrails/core/reportusage.py
+++ b/vistrails/core/reportusage.py
@@ -251,20 +251,14 @@ def get_ca_certificate():
 
 _default_news = {
     'version': '20160304',
-    'news_html':
-        u"<p>We are conducting a survey of VisTrails users. "
-        u"<a href=\"http://www.vistrails.org/\" target=\"_blank\">If you have "
-        u"a minute, please consider helping us by visiting this page.</a></p>",
+    'news_html': None,
     'usage_report_prompt_html':
         u"<p>Please help us by reporting anonymous statistics about how you "
         u"use VisTrails.</p><p>We would like to collect high-level details "
         u"like which packages you use, which features, the size of your "
         u"workflows and version trees, ... This information is reported "
         u"anonymously and will only be used by the VisTrails team, to help "
-        u"guide our efforts.</p>"
-        u"<p><a href=\"http://www.vistrails.org/\" target=\"_blank\">We are "
-        u"also conducting a survey of VisTrails users. If you have a minute, "
-        u"please consider helping us by visiting this page.</a></p>",
+        u"guide our efforts.</p>",
 }
 
 

--- a/vistrails/core/reportusage.py
+++ b/vistrails/core/reportusage.py
@@ -48,7 +48,8 @@ import usagestats
 import weakref
 
 from vistrails.core import debug
-from vistrails.core.system import vistrails_version
+from vistrails.core.system import vistrails_version, \
+    vistrails_examples_directory
 
 
 usage_report = None
@@ -119,6 +120,7 @@ def record_vistrail(what, vistrail):
     from vistrails.core.vistrail.controller import VistrailController
     from vistrails.core.vistrail.pipeline import Pipeline
     from vistrails.core.vistrail.vistrail import Vistrail
+    from vistrails.db.services.locator import XMLFileLocator
 
     if isinstance(vistrail, VistrailController):
         vistrail = vistrail.vistrail
@@ -149,6 +151,10 @@ def record_vistrail(what, vistrail):
             elif annotation.key == Vistrail.PARAMEXP_ANNOTATION:
                 nb_paramexplorations += 1
         nb_upgrades = len(upgrade_from - upgrade_to)
+        if isinstance(vistrail.locator, XMLFileLocator):
+            usage_report.note({'in_examples_dir':
+                os.path.realpath(vistrail.locator._name).startswith(
+                    os.path.realpath(vistrails_examples_directory()))})
         usage_report.note(dict(use_vistrail=what,
                                nb_versions=len(vistrail.actionMap),
                                nb_tags=len(vistrail.tags),

--- a/vistrails/gui/application.py
+++ b/vistrails/gui/application.py
@@ -200,6 +200,8 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
         Create the application with a dict of settings
         
         """
+        reportusage.record_usage(gui=True)
+
         vistrails.gui.theme.initializeCurrentTheme()
         VistrailsApplicationInterface.init(self, optionsDict, args)
         
@@ -229,6 +231,7 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
         # The window does not get maximized. If we do it too early,
         # there are no created windows during spreadsheet initialization.
         if interactive:
+            reportusage.record_usage(gui_interactive=True)
             if  self.temp_configuration.check('maximizeWindows'):
                 self.builderWindow.showMaximized()
             if self.temp_configuration.check('dbDefault'):

--- a/vistrails/gui/application.py
+++ b/vistrails/gui/application.py
@@ -267,16 +267,7 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
         descr = QtGui.QTextBrowser()
         descr.setOpenExternalLinks(True)
         descr.setHtml(
-            u"<p>Please help us by reporting anonymous statistics about how "
-            u"you use VisTrails.</p>"
-            u"<p>We would like to collect high-level details like which "
-            u"packages you use, which features, the size of your workflows "
-            u"and version trees, ... This information is reported anonymously "
-            u"and will only be used by the VisTrails team, to help guide our "
-            u"efforts.</p>"
-            u"<p><a href=\"http://www.vistrails.org/\" target=\"_blank\">We are also conducting "
-            u"a survey of VisTrails users. If you have a minute, please "
-            u"consider helping us by visiting this page.</a></p>")
+            reportusage.get_server_news()['usage_report_prompt_html'])
         layout.addWidget(descr)
         layout.addWidget(QtGui.QLabel(
             u"Send anonymous reports to the developers?"))

--- a/vistrails/gui/application.py
+++ b/vistrails/gui/application.py
@@ -242,6 +242,9 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
         # usage statistics
         if reportusage.usage_report.status is usagestats.Stats.UNSET:
             self.ask_enable_usage_report()
+        # news
+        elif self.temp_configuration.check('showVistrailsNews'):
+            self.show_news()
 
         # default handler installation
         if system.systemType == 'Linux':
@@ -258,6 +261,7 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
         return APP_SUCCESS
 
     def ask_enable_usage_report(self):
+        news = reportusage.get_server_news()
         if hasattr(self, 'splashScreen') and self.splashScreen:
             self.splashScreen.hide()
         dialog = QtGui.QDialog()
@@ -266,8 +270,7 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
         dialog.setLayout(layout)
         descr = QtGui.QTextBrowser()
         descr.setOpenExternalLinks(True)
-        descr.setHtml(
-            reportusage.get_server_news()['usage_report_prompt_html'])
+        descr.setHtml(news['usage_report_prompt_html'])
         layout.addWidget(descr)
         layout.addWidget(QtGui.QLabel(
             u"Send anonymous reports to the developers?"))
@@ -287,6 +290,27 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
         else:
             if dont_ask.isChecked():
                 reportusage.usage_report.disable_reporting()
+        self.configuration.lastShownNews = news['version']
+
+    def show_news(self):
+        news = reportusage.get_server_news()
+        if (getattr(self.temp_configuration, 'lastShownNews', None) ==
+                news['version']):
+            return
+
+        if news['news_html']:
+            if hasattr(self, 'splashScreen') and self.splashScreen:
+                self.splashScreen.hide()
+            dialog = QtGui.QDialog()
+            dialog.setWindowTitle(u"VisTrails News")
+            layout = QtGui.QVBoxLayout()
+            dialog.setLayout(layout)
+            descr = QtGui.QTextBrowser()
+            descr.setOpenExternalLinks(True)
+            descr.setHtml(news['news_html'])
+            layout.addWidget(descr)
+            dialog.exec_()
+        self.configuration.lastShownNews = news['version']
 
     def ask_update_default_application(self, dont_ask_checkbox=True):
         if hasattr(self, 'splashScreen') and self.splashScreen:

--- a/vistrails/gui/application.py
+++ b/vistrails/gui/application.py
@@ -309,6 +309,15 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
             descr.setOpenExternalLinks(True)
             descr.setHtml(news['news_html'])
             layout.addWidget(descr)
+
+            hlayout = QtGui.QHBoxLayout()
+            button = QtGui.QPushButton('&Close')
+            hlayout.addStretch(1)
+            hlayout.addWidget(button)
+            hlayout.addStretch(1)
+            layout.addLayout(hlayout)
+            button.clicked.connect(dialog.close)
+
             dialog.exec_()
         self.configuration.lastShownNews = news['version']
 

--- a/vistrails/gui/application.py
+++ b/vistrails/gui/application.py
@@ -819,6 +819,7 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
         return False
 
     def parse_input_args_from_other_instance(self, msg):
+        reportusage.record_feature('args_from_other_instance')
         options_re = re.compile(r"^(\[('([^'])*', ?)*'([^']*)'\])|(\[\s?\])$")
         if options_re.match(msg):
             #it's safe to eval as a list

--- a/vistrails/gui/paramexplore/pe_tab.py
+++ b/vistrails/gui/paramexplore/pe_tab.py
@@ -47,6 +47,7 @@ from vistrails.core import debug
 from vistrails.core.interpreter.default import get_default_interpreter
 from vistrails.core.modules.module_registry import get_module_registry
 from vistrails.core.param_explore import ActionBasedParameterExploration
+from vistrails.core import reportusage
 from vistrails.core.system import current_time, strftime
 from vistrails.gui.common_widgets import QDockContainer, QToolWindowInterface
 from vistrails.gui.paramexplore.pe_table import QParameterExplorationWidget, QParameterSetEditor
@@ -266,6 +267,7 @@ class QParameterExplorationTab(QDockContainer, QToolWindowInterface):
         corresponding to each dimension
         
         """
+        reportusage.record_feature('paramexplore', self.controller)
         registry = get_module_registry()
         actions = self.peWidget.table.collectParameterActions()
         spreadsheet_pkg = 'org.vistrails.vistrails.spreadsheet'

--- a/vistrails/gui/vistrail_view.py
+++ b/vistrails/gui/vistrail_view.py
@@ -53,6 +53,7 @@ from vistrails.core.log.prov_document import ProvDocument
 from vistrails.core.db.locator import XMLFileLocator
 from vistrails.core.modules.module_registry import ModuleRegistry
 from vistrails.core.configuration import get_vistrails_configuration
+from vistrails.core import reportusage
 
 from vistrails.gui.collection.vis_log import QLogView
 from vistrails.gui.common_widgets import QMouseTabBar
@@ -891,6 +892,7 @@ class QVistrailView(QtGui.QWidget):
         self.switch_to_tab(view.tab_idx)
         view.scene().fitToView(view, True)
         self.view_changed()
+        reportusage.record_feature('diff', self.controller)
 
     def save_vistrail(self, locator_class, force_choose_locator=False, export=False):
         """

--- a/vistrails/gui/vistrail_view.py
+++ b/vistrails/gui/vistrail_view.py
@@ -41,6 +41,7 @@ from PyQt4 import QtCore, QtGui
 
 from vistrails.core import debug
 from vistrails.core.collection import Collection
+from vistrails.core.reportusage import record_vistrail
 from vistrails.core.system import vistrails_default_file_type, \
     vistrails_file_directory
 from vistrails.core.thumbnails import ThumbnailCache
@@ -920,6 +921,7 @@ class QVistrailView(QtGui.QWidget):
         if not locator:
             return False
         try:
+            record_vistrail('save', self.controller)
             self.controller.write_vistrail(locator, export=export)
         except Exception:
             debug.critical('Failed to save vistrail', debug.format_exc())
@@ -978,6 +980,7 @@ class QVistrailView(QtGui.QWidget):
         locator = gui_get(self, Pipeline.vtType)
         if not locator:
             return False
+        record_vistrail('export_stable', self.controller.current_pipeline)
         self.controller.write_workflow(locator, '1.0.3')
         return True
 
@@ -995,6 +998,7 @@ class QVistrailView(QtGui.QWidget):
             locator = gui_get(self, Pipeline.vtType, self.controller.locator)
         if not locator:
             return False
+        record_vistrail('save_pipeline', self.controller.current_pipeline)
         self.controller.write_workflow(locator)
 
     def save_log(self, locator_class, force_choose_locator=True):

--- a/vistrails/gui/vistrails_window.py
+++ b/vistrails/gui/vistrails_window.py
@@ -48,6 +48,7 @@ from vistrails.core.interpreter.cached import CachedInterpreter
 from vistrails.core.recent_vistrails import RecentVistrailList
 import vistrails.core.system
 import vistrails.core.db.action
+from vistrails.core.reportusage import record_vistrail
 from vistrails.core.system import vistrails_default_file_type
 from vistrails.core.vistrail.vistrail import Vistrail
 from vistrails.core.vistrail.pipeline import Pipeline
@@ -1869,6 +1870,7 @@ class QVistrailsWindow(QVistrailViewWindow):
         
         if locator is not None:
             get_vistrails_application().close_vistrail(locator, current_view.controller)
+        record_vistrail('close', current_view.controller)
         return True
 
     def close_all_vistrails(self, quiet=False):

--- a/vistrails/run.py
+++ b/vistrails/run.py
@@ -126,6 +126,10 @@ def main():
     from vistrails.core import debug
     debug.DebugPrint.getInstance().log_to_console()
 
+    # Setup usage reporting
+    from vistrails.core import reportusage
+    reportusage.setup_usage_report()
+
     from vistrails.gui.requirements import require_pyqt4_api2
     require_pyqt4_api2()
 

--- a/vistrails/run.py
+++ b/vistrails/run.py
@@ -147,6 +147,8 @@ def main():
         app = vistrails.gui.application.get_vistrails_application()
         if app:
             app.finishSession()
+        reportusage.submit_usage_report(result='init exit %s' %
+                                               getattr(e, 'code', '(unknown)'))
         sys.exit(e)
     except Exception, e:
         app = vistrails.gui.application.get_vistrails_application()
@@ -156,11 +158,17 @@ def main():
         print >>sys.stderr, "Uncaught exception on initialization: %s" % (
                 traceback._format_final_exc_line(type(e).__name__, e).strip())
         traceback.print_exc(None, sys.stderr)
+        reportusage.submit_usage_report(result='init %s' % type(e).__name__)
         sys.exit(255)
-    if not app.temp_configuration.batch:
-        v = app.exec_()
 
-    vistrails.gui.application.stop_application()
+    try:
+        if not app.temp_configuration.batch:
+            v = app.exec_()
+        vistrails.gui.application.stop_application()
+    except BaseException, e:
+        reportusage.submit_usage_report(result=type(e).__name__)
+        raise
+    reportusage.submit_usage_report(result='success %s' % v)
     sys.exit(v)
 
 if __name__ == '__main__':

--- a/vistrails/tests/runtestsuite.py
+++ b/vistrails/tests/runtestsuite.py
@@ -180,6 +180,11 @@ if debug_mode:
 import vistrails.core.debug
 vistrails.core.debug.DebugPrint.getInstance().log_to_console()
 
+# Disable usage reporting
+os.environ['VISTRAILS_USAGE_STATS'] = 'off'
+from vistrails.core import reportusage
+reportusage.setup_usage_report()
+
 import vistrails.tests
 import vistrails.core
 import vistrails.core.db.io

--- a/vistrails/tests/runtestsuite.py
+++ b/vistrails/tests/runtestsuite.py
@@ -273,6 +273,7 @@ optionsDict = {
         'developerDebugger': debug_mode,
         'debugLevel': vistrails_verbose,
         'dontUnloadModules': True,
+        'showVistrailsNews': False,
     }
 if dotVistrails:
     optionsDict['dotVistrails'] = dotVistrails


### PR DESCRIPTION
This brings in the usagestats package developed for ReproZip (ViDA-NYU/reprozip#75).

Fixes #1148

* [X] Add usagestats machinery
* [x] Enable/disable from GUI
* [x] Enable/disable from command-line
* Add calls everywhere to report feature usage
  * [x] Size of vistrail (number of versions, tags, modules)
  * [X] Package usage
  * [x] Environment (Anaconda? Binary? Python version, dependencies available and versions)
  * [x] Execution time
  * [x] Using groups, subworkflows
  * [x] Using parameter explorations, queries, diffs
  * [ ] Used in batch mode, LaTeX extension?
* [x] Link to survey form in popup