### PR TITLE
Chain upgrades when using hideUpgrades

### DIFF
--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -3702,14 +3702,16 @@ class VistrailController(object):
                                                      from_root=from_root,
                                                      use_current=use_current)
                         version = upgrade_version
-                        start_version = version
                         was_upgraded = True
-                except InvalidPipeline:
+                # Do not remove "e", it is used in the next step
+                except InvalidPipeline, e:
+                    version = upgrade_version
                     # try to handle using the handler and create
                     # new upgrade
                     pass
             if not was_upgraded:
                 try:
+                    # use upgraded pipeline
                     version, pipeline = \
                         self.handle_invalid_pipeline(e, version,
                                                      self.vistrail,

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -3011,8 +3011,10 @@ class VistrailController(object):
                     pass
                 # An upgrade: get its children directly
                 # (unless it is tagged, and that tag couldn't be moved)
-                elif (not self.show_upgrades and child in upgrades and
-                        child not in tm):
+                elif (not self.show_upgrades and
+                      (child in upgrades or
+                       am[child].description == 'Upgrade') and
+                      child not in tm):
                     all_children.extend(
                         to for to, _ in fullVersionTree.adjacency_list[child]
                         if to in am)

--- a/vistrails/core/vistrail/vistrail.py
+++ b/vistrails/core/vistrail/vistrail.py
@@ -1108,6 +1108,34 @@ class Vistrail(DBVistrail):
                     version = upgrade_rev_map[version]
         return None
 
+    def get_upgrade_chain(self, base_version, start_at_base=False):
+        """Returns upgrade chain for version.
+
+        :param base_version: a version in the upgrade chain
+        :param start_at_base: if False (default), return chain starting with
+        given version. If True, start from the original action (the one that's
+        not an upgrade). If False, go down from given version only.
+        :returns: The list version ids in the upgrade chain
+        """
+        # TODO: cache these maps somewhere
+        upgrade_map = {}
+        upgrade_rev_map = {}
+        for ann in self.action_annotations:
+            if ann.key == Vistrail.UPGRADE_ANNOTATION:
+                upgrade_map[ann.action_id] = int(ann.value)
+                upgrade_rev_map[int(ann.value)] = ann.action_id
+        if start_at_base is True:
+            while base_version in upgrade_rev_map:
+                base_version = upgrade_rev_map[base_version]
+
+        chain = []
+        version = base_version
+        walked_versions = set()
+        while version is not None and version not in walked_versions:
+            chain.append(version)
+            walked_versions.add(version)
+            version = upgrade_map.get(version)
+        return chain
 
 ##############################################################################
 

--- a/vistrails/gui/vistrail_controller.py
+++ b/vistrails/gui/vistrail_controller.py
@@ -1465,3 +1465,46 @@ class TestVistrailController(vistrails.gui.utils.TestVisTrailsGUI):
         self.assertEqual(c.execute_current_workflow()[0][0].errors, {})
         api.close_current_vistrail(True)
         c.unload_abstractions()
+
+    def test_chained_upgrade(self):
+        # We should try to upgrade from the latest upgrade in
+        # the upgrade chain first
+        from vistrails import api
+        view = api.open_vistrail_from_file(
+                vistrails.core.system.vistrails_root_directory() +
+                '/tests/resources/chained_upgrade.xml')
+        # Trigger upgrade
+        api.select_version('myTuple')
+        view.execute()
+        # Assert new upgrade was created from the latest action
+        # 1 = original
+        # 2 = old upgrade
+        # 3 = new upgrade (should be the upgrade of 2)
+        vistrail = api.get_current_vistrail()
+        for a in vistrail.action_annotations:
+            if a.key == Vistrail.UPGRADE_ANNOTATION:
+                self.assertIn(a.action_id, [1,2])
+                if a.action_id == 1:
+                    self.assertEqual(int(a.value), 2)
+                if a.action_id == 2:
+                    self.assertEqual(int(a.value), 3)
+
+    def test_broken_upgrade(self):
+        # When upgrade is broken the controller should try to upgrade
+        # the previous action in the upgrade chain
+        from vistrails import api
+        view = api.open_vistrail_from_file(
+                vistrails.core.system.vistrails_root_directory() +
+                '/tests/resources/broken_upgrade.xml')
+        # Trigger upgrade
+        api.select_version('myTuple')
+        view.execute()
+        # Assert new upgrade was created from the first action
+        # 1 = original
+        # 2 = broken
+        # 3 = new (should be the upgrade of 1)
+        vistrail = api.get_current_vistrail()
+        for a in vistrail.action_annotations:
+            if a.key == Vistrail.UPGRADE_ANNOTATION:
+                self.assertEqual(a.action_id, 1)
+                self.assertEqual(int(a.value), 3)

--- a/vistrails/tests/resources/broken_upgrade.xml
+++ b/vistrails/tests/resources/broken_upgrade.xml
@@ -1,0 +1,23 @@
+<vistrail id="" name="" version="1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vistrails.org/vistrail.xsd">
+  <action date="2001-11-22 17:08:50" id="1" prevId="0" session="0" user="god">
+    <add id="0" objectId="0" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="0" name="Tuple" namespace="" package="edu.utah.sci.vistrails.basic" version="1.6" />
+    </add>
+    <add id="1" objectId="0" parentObjId="0" parentObjType="module" what="location">
+      <location id="0" x="0.0" y="0.0" />
+    </add>
+  </action>
+  <action date="2002-11-23 15:11:51" id="2" prevId="1" session="2" user="god">
+    <annotation id="0" key="__description__" value="Upgrade" />
+    <delete id="2" objectId="0" parentObjId="0" parentObjType="module" what="location" />
+    <delete id="3" objectId="0" parentObjId="" parentObjType="" what="module" />
+    <add id="4" objectId="1" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="1" name="BrokenUpgrade" namespace="" package="edu.utah.sci.vistrails.basic" version="10.0" />
+    </add>
+    <add id="5" objectId="1" parentObjId="1" parentObjType="module" what="location">
+      <location id="1" x="0.0" y="0.0" />
+    </add>
+  </action>
+  <actionAnnotation actionId="1" date="2002-09-12 14:41:53" id="0" key="__upgrade__" user="tommy" value="2" />
+  <actionAnnotation actionId="1" date="2002-09-12 14:42:20" id="1" key="__tag__" user="tommy" value="myTuple" />
+</vistrail>

--- a/vistrails/tests/resources/chained_upgrade.xml
+++ b/vistrails/tests/resources/chained_upgrade.xml
@@ -1,0 +1,23 @@
+<vistrail id="" name="" version="1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vistrails.org/vistrail.xsd">
+  <action date="2001-11-22 17:08:50" id="1" prevId="0" session="0" user="god">
+    <add id="0" objectId="0" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="0" name="Tuple" namespace="" package="edu.utah.sci.vistrails.basic" version="1.0" />
+    </add>
+    <add id="1" objectId="0" parentObjId="0" parentObjType="module" what="location">
+      <location id="0" x="0.0" y="0.0" />
+    </add>
+  </action>
+  <action date="2002-11-23 15:11:51" id="2" prevId="1" session="2" user="god">
+    <annotation id="0" key="__description__" value="Upgrade" />
+    <delete id="2" objectId="0" parentObjId="0" parentObjType="module" what="location" />
+    <delete id="3" objectId="0" parentObjId="" parentObjType="" what="module" />
+    <add id="4" objectId="1" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="1" name="Tuple" namespace="" package="edu.utah.sci.vistrails.basic" version="1.6" />
+    </add>
+    <add id="5" objectId="1" parentObjId="1" parentObjType="module" what="location">
+      <location id="1" x="0.0" y="0.0" />
+    </add>
+  </action>
+  <actionAnnotation actionId="1" date="2002-09-12 14:41:53" id="0" key="__upgrade__" user="tommy" value="2" />
+  <actionAnnotation actionId="1" date="2002-09-12 14:42:20" id="1" key="__tag__" user="tommy" value="myTuple" />
+</vistrail>


### PR DESCRIPTION
`hideUpgrades` makes a node always refer to the original version in a tagged upgrade chain, so upgrades gets added from that one, not from the latest existing upgrade. This PR fixes this by selecting the latest upgrade before upgrading.

This is motivated by an example from terminator:
We have an action chain ``A->B`` where B is tagged (Not really good to tag upgrade nodes, but anyway).
Originally, trying to upgrade this would destroy the old action chain and create a new action chain ``A->C``. The tag for B would no longer be associated with this chain and strange things may happen.
With this PR, using chained upgrades, we try to upgrade from B, and get ``A->B->C``, which will work as expected.

If upgrade is broken or too new we should fall back to previous upgrade(s), i.e, if B is broken we may still need to upgrade from A. This would break the old action chain, but that is better than settling for an invalid pipeline.

TODO: Needs test