### PR TITLE
Recurse handle_invalid_pipeline

### DIFF
--- a/vistrails/core/configuration.py
+++ b/vistrails/core/configuration.py
@@ -767,7 +767,8 @@ base_config = {
      ConfigField('rootDirectory', None, ConfigPath, ConfigType.INTERNAL),
      ConfigField('developerDebugger', False, bool, ConfigType.INTERNAL),
      ConfigField('dontUnloadModules', False, bool, ConfigType.INTERNAL),
-     ConfigField('bundleDeclinedList', '', str, ConfigType.INTERNAL)],
+     ConfigField('bundleDeclinedList', '', str, ConfigType.INTERNAL),
+     ConfigField('maxPipelineFixAttempts', 50, int, ConfigType.INTERNAL)],
     "Jobs":
     [ConfigField('jobCheckInterval', 600, int),
      ConfigField('jobAutorun', False, bool),

--- a/vistrails/core/upgradeworkflow.py
+++ b/vistrails/core/upgradeworkflow.py
@@ -54,6 +54,7 @@ from vistrails.core.vistrail.port_spec import PortSpec
 from vistrails.core.vistrail.port_spec_item import PortSpecItem
 from vistrails.core.utils import versions_increasing
 import copy
+import os
 
 ##############################################################################
 
@@ -1007,6 +1008,72 @@ class TestUpgradePackageRemap(unittest.TestCase):
                 pass
             app.temp_configuration.upgrades = default_upgrades
             app.temp_configuration.upgradeDelay = default_upgrade_delay
+
+    def test_looping_pipeline_fix(self):
+        """Chains upgrades and automatic package initialization."""
+        # Expected actions are as follow:
+        #  - loads workflow.xml
+        #  * pipeline is missing looping_fix.a version 0.1
+        #  - enables looping_fix.a (version 0.2)
+        #  * pipeline is still missing looping_fix.a version 0.1
+        #  - runs upgrade for looping_fix.a, 0.1 -> 0.2
+        #  - upgrade changes modules to package looping_fix.b version 0.1
+        #  * pipeline is missing looping_fix.b version 0.1
+        #  - enables looping_fix.b (version 0.2)
+        #  * pipeline is still missing looping_fix.b version 0.1
+        #  - runs upgrade for looping_fix.b, 0.1 -> 0.2
+        #  - upgrade changes modules to package looping_fix.c version 1.0
+        #  * pipeline is missing looping_fix.c version 1.0
+        #  - enables looping_fix.c (version 1.0)
+        #  * pipeline is valid
+        # 5 calls to handle_invalid_pipeline()
+
+        # Pre-adds packages so that the package manager can find them
+        packages = ['pkg_a', 'pkg_b', 'pkg_c']
+        prefix = 'vistrails.tests.resources.looping_upgrades.'
+        pm = get_package_manager()
+        for pkg in packages:
+            pm.get_available_package(pkg, prefix=prefix)
+        self.assertFalse(set(pkg.codepath for pkg in pm.enabled_package_list())
+                         .intersection(packages))
+
+        # Hooks handle_invalid_pipeline()
+        from vistrails.core.vistrail.controller import VistrailController
+        orig_hip = VistrailController.handle_invalid_pipeline
+        count = [0]
+        def new_hip(*args, **kwargs):
+            count[0] += 1
+            return orig_hip(*args, **kwargs)
+        VistrailController.handle_invalid_pipeline = new_hip
+        try:
+
+            # Loads workflow.xml
+            from vistrails.core.db.io import load_vistrail
+            from vistrails.core.db.locator import FileLocator
+            from vistrails.core.system import vistrails_root_directory
+
+            locator = FileLocator(os.path.join(
+                    vistrails_root_directory(),
+                    'tests', 'resources', 'looping_upgrades',
+                    'workflow.xml'))
+            loaded_objs = load_vistrail(locator)
+            controller = VistrailController(
+                    loaded_objs[0], locator, *loaded_objs[1:])
+
+            # Select version (triggers all the validation/upgrade/loading)
+            self.assertEqual(controller.get_latest_version_in_graph(), 1)
+            controller.do_version_switch(1)
+
+        # Restores handle_invalid_pipeline()
+        finally:
+            VistrailController.handle_invalid_pipeline = orig_hip
+            # disable packages
+            for pkg in reversed(packages):
+                try:
+                    pm.late_disable_package(pkg)
+                except MissingPackage:
+                    pass
+
 
 if __name__ == '__main__':
     import vistrails.core.application

--- a/vistrails/core/upgradeworkflow.py
+++ b/vistrails/core/upgradeworkflow.py
@@ -1064,6 +1064,7 @@ class TestUpgradePackageRemap(unittest.TestCase):
             self.assertEqual(controller.get_latest_version_in_graph(), 1)
             controller.do_version_switch(1)
 
+            self.assertEqual(count[0], 3)
         # Restores handle_invalid_pipeline()
         finally:
             VistrailController.handle_invalid_pipeline = orig_hip

--- a/vistrails/core/upgradeworkflow.py
+++ b/vistrails/core/upgradeworkflow.py
@@ -42,6 +42,7 @@ import copy
 import os
 
 from vistrails.core import debug
+from vistrails.core.configuration import get_vistrails_configuration
 import vistrails.core.db.action
 from vistrails.core.modules.module_registry import get_module_registry, \
      ModuleDescriptor, MissingModule, MissingPort, MissingPackage
@@ -1151,7 +1152,9 @@ class TestUpgradePackageRemap(unittest.TestCase):
                 except MissingPackage:
                     pass
         # make sure it looped 50 times before failing
-        self.assertEqual(count[0], 50)
+        max_loops = getattr(get_vistrails_configuration(),
+                            'maxPipelineFixAttempts', 50)
+        self.assertEqual(count[0], max_loops)
         # Check that original version gets selected
         self.assertEqual(1, controller.current_version)
 

--- a/vistrails/core/upgradeworkflow.py
+++ b/vistrails/core/upgradeworkflow.py
@@ -780,7 +780,11 @@ class UpgradeWorkflowHandler(object):
                 new_module_t = new_module_desc.spec_tuple
 
             new_pkg_version = module_remap.output_version
-            if (new_pkg_version is None or
+            next_module_remap = None
+            if isinstance(new_module_type, ModuleDescriptor):
+                new_module_desc = new_module_type
+                use_registry = False
+            elif (new_pkg_version is None or
                   reg.get_package_by_name(new_module_t[0]).version == new_pkg_version):
                 # upgrading to the current version
                 try:
@@ -793,7 +797,6 @@ class UpgradeWorkflowHandler(object):
                     else:
                         raise e
                 use_registry = True
-                next_module_remap = None
             else:
                 new_module_desc = ModuleDescriptor(package=new_module_t[0],
                                                    name=new_module_t[1],

--- a/vistrails/core/upgradeworkflow.py
+++ b/vistrails/core/upgradeworkflow.py
@@ -1070,7 +1070,7 @@ class TestUpgradePackageRemap(unittest.TestCase):
             self.assertEqual(controller.get_latest_version_in_graph(), 1)
             controller.do_version_switch(1)
 
-            self.assertEqual(count[0], 3)
+            self.assertEqual(count[0], 5)
         # Restores handle_invalid_pipeline()
         finally:
             VistrailController.handle_invalid_pipeline = orig_hip
@@ -1080,7 +1080,6 @@ class TestUpgradePackageRemap(unittest.TestCase):
                     pm.late_disable_package(pkg)
                 except MissingPackage:
                     pass
-        self.assertEqual(count[0], 5)
 
     def test_infinite_looping_upgrade(self):
         """Test that circular upgrades fail gracefully"""

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -3651,7 +3651,9 @@ class VistrailController(object):
             # run handle_invalid_pipeline again.
             # each level creates a new upgrade
             level += 1
-            if level == 50:
+            max_loops = getattr(get_vistrails_configuration(),
+                                'maxPipelineFixAttempts', 50)
+            if level >= max_loops:
                 debug.critical(
                         "Pipeline-fixing loop doesn't seem to "
                         "be finishing, giving up after %d "

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -3634,6 +3634,7 @@ class VistrailController(object):
             try:
                 self.validate(cur_pipeline)
             except InvalidPipeline, e:
+                e._version = new_version
                 new_err = e
 
         if new_err is not None:

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -3702,14 +3702,16 @@ class VistrailController(object):
                                                      from_root=from_root,
                                                      use_current=use_current)
                         version = upgrade_version
-                        start_version = version
                         was_upgraded = True
-                except InvalidPipeline:
+                # Do not remove "e", it is used in the next step
+                except InvalidPipeline, e:
+                    version = upgrade_version
                     # try to handle using the handler and create
                     # new upgrade
                     pass
             if not was_upgraded:
                 try:
+                    # use upgraded pipeline
                     version, pipeline = \
                         self.handle_invalid_pipeline(e, version,
                                                      self.vistrail,

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -3308,6 +3308,7 @@ class VistrailController(object):
     def handle_invalid_pipeline(self, e, new_version, vistrail=None,
                                 report_all_errors=False, force_no_delay=False,
                                 delay_update=False, level=0):
+        debug.log('Running handle_invalid_pipeline on %d' % new_version)
         if delay_update:
             force_no_delay = True
         def check_exceptions(exception_set):
@@ -3620,8 +3621,16 @@ class VistrailController(object):
 
         left_exceptions = check_exceptions(root_exceptions)
         # If exceptions unchanged, fail.
+        debug.log(('handle_invalid_pipeline finished with %d fixed, %d left, '
+                   'and %d new exceptions') % ((len(root_exceptions) -
+                                                    len(left_exceptions)),
+                                                   len(left_exceptions),
+                                                   len(new_exceptions)))
         if (len(left_exceptions) == len(root_exceptions) and
             len(new_exceptions) == 0):
+            debug.log('handle_invalid_pipeline failed to validate version '
+                      '%d: %d errors left.' % (new_version,
+                                               len(root_exceptions)))
             raise InvalidPipeline(left_exceptions + new_exceptions,
                                   cur_pipeline, new_version)
         new_err = None
@@ -3649,6 +3658,8 @@ class VistrailController(object):
                         "iterations. You may have circular "
                         "upgrade paths!" % level)
             else:
+                debug.log('Recursing handle_invalid_pipeline on '
+                          'version %d to level %d' % (new_version, level))
                 return self.handle_invalid_pipeline(new_err,
                                                     new_version,
                                                     vistrail,

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -3308,7 +3308,7 @@ class VistrailController(object):
     def handle_invalid_pipeline(self, e, new_version, vistrail=None,
                                 report_all_errors=False, force_no_delay=False,
                                 delay_update=False, level=0):
-        debug.log('Running handle_invalid_pipeline on %d' % new_version)
+        debug.debug('Running handle_invalid_pipeline on %d' % new_version)
         if delay_update:
             force_no_delay = True
         def check_exceptions(exception_set):
@@ -3457,7 +3457,7 @@ class VistrailController(object):
                     continue
                 details = '\n'.join(debug.format_exception(e)
                                     for e in err_list)
-                debug.log('Processing upgrades in package "%s"' %
+                debug.debug('Processing upgrades in package "%s"' %
                           identifier, details)
                 if pkg.can_handle_all_errors():
                     try:
@@ -3621,15 +3621,15 @@ class VistrailController(object):
 
         left_exceptions = check_exceptions(root_exceptions)
         # If exceptions unchanged, fail.
-        debug.log(('handle_invalid_pipeline finished with %d fixed, %d left, '
-                   'and %d new exceptions') % ((len(root_exceptions) -
-                                                    len(left_exceptions)),
-                                                   len(left_exceptions),
-                                                   len(new_exceptions)))
+        debug.debug(('handle_invalid_pipeline finished with %d fixed, %d left, '
+                     'and %d new exceptions') % ((len(root_exceptions) -
+                                                  len(left_exceptions)),
+                                                 len(left_exceptions),
+                                                 len(new_exceptions)))
         if (len(left_exceptions) == len(root_exceptions) and
             len(new_exceptions) == 0):
-            debug.log('handle_invalid_pipeline failed to validate version '
-                      '%d: %d errors left.' % (new_version,
+            debug.debug('handle_invalid_pipeline failed to validate version '
+                        '%d: %d errors left.' % (new_version,
                                                len(root_exceptions)))
             raise InvalidPipeline(left_exceptions + new_exceptions,
                                   cur_pipeline, new_version)
@@ -3660,8 +3660,8 @@ class VistrailController(object):
                         "iterations. You may have circular "
                         "upgrade paths!" % level)
             else:
-                debug.log('Recursing handle_invalid_pipeline on '
-                          'version %d to level %d' % (new_version, level))
+                debug.debug('Recursing handle_invalid_pipeline on '
+                            'version %d to level %d' % (new_version, level))
                 return self.handle_invalid_pipeline(new_err,
                                                     new_version,
                                                     vistrail,

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -3641,11 +3641,13 @@ class VistrailController(object):
             # There are still unresolved exceptions (old or new), try to
             # run handle_invalid_pipeline again.
             # each level creates a new upgrade
-            if level == 4:
+            level += 1
+            if level == 50:
                 debug.critical(
                         "Pipeline-fixing loop doesn't seem to "
                         "be finishing, giving up after %d "
-                        "iterations" % level)
+                        "iterations. You may have circular "
+                        "upgrade paths!" % level)
             else:
                 return self.handle_invalid_pipeline(new_err,
                                                     new_version,
@@ -3653,7 +3655,7 @@ class VistrailController(object):
                                                     report_all_errors,
                                                     force_no_delay,
                                                     delay_update,
-                                                    level+1)
+                                                    level)
             raise new_err
         return new_version, cur_pipeline
 
@@ -3754,7 +3756,7 @@ class VistrailController(object):
             # first try without upgrading
             pipeline = self.get_pipeline(version, from_root=from_root,
                                          use_current=use_current)
-        except InvalidPipeline, e:
+        except InvalidPipeline:
             # Try latest upgrade first, then try previous upgrades.
             # If all fail, return latest upgrade exception.
             upgrade_chain = self.vistrail.get_upgrade_chain(version, True)

--- a/vistrails/core/vistrail/controller.py
+++ b/vistrails/core/vistrail/controller.py
@@ -3011,8 +3011,10 @@ class VistrailController(object):
                     pass
                 # An upgrade: get its children directly
                 # (unless it is tagged, and that tag couldn't be moved)
-                elif (not self.show_upgrades and child in upgrades and
-                        child not in tm):
+                elif (not self.show_upgrades and
+                      (child in upgrades or
+                       am[child].description == 'Upgrade') and
+                      child not in tm):
                     all_children.extend(
                         to for to, _ in fullVersionTree.adjacency_list[child]
                         if to in am)

--- a/vistrails/core/vistrail/vistrail.py
+++ b/vistrails/core/vistrail/vistrail.py
@@ -1108,6 +1108,34 @@ class Vistrail(DBVistrail):
                     version = upgrade_rev_map[version]
         return None
 
+    def get_upgrade_chain(self, base_version, start_at_base=False):
+        """Returns upgrade chain for version.
+
+        :param base_version: a version in the upgrade chain
+        :param start_at_base: if False (default), return chain starting with
+        given version. If True, start from the original action (the one that's
+        not an upgrade). If False, go down from given version only.
+        :returns: The list version ids in the upgrade chain
+        """
+        # TODO: cache these maps somewhere
+        upgrade_map = {}
+        upgrade_rev_map = {}
+        for ann in self.action_annotations:
+            if ann.key == Vistrail.UPGRADE_ANNOTATION:
+                upgrade_map[ann.action_id] = int(ann.value)
+                upgrade_rev_map[int(ann.value)] = ann.action_id
+        if start_at_base is True:
+            while base_version in upgrade_rev_map:
+                base_version = upgrade_rev_map[base_version]
+
+        chain = []
+        version = base_version
+        walked_versions = set()
+        while version is not None and version not in walked_versions:
+            chain.append(version)
+            walked_versions.add(version)
+            version = upgrade_map.get(version)
+        return chain
 
 ##############################################################################
 

--- a/vistrails/gui/vistrail_controller.py
+++ b/vistrails/gui/vistrail_controller.py
@@ -1465,3 +1465,46 @@ class TestVistrailController(vistrails.gui.utils.TestVisTrailsGUI):
         self.assertEqual(c.execute_current_workflow()[0][0].errors, {})
         api.close_current_vistrail(True)
         c.unload_abstractions()
+
+    def test_chained_upgrade(self):
+        # We should try to upgrade from the latest upgrade in
+        # the upgrade chain first
+        from vistrails import api
+        view = api.open_vistrail_from_file(
+                vistrails.core.system.vistrails_root_directory() +
+                '/tests/resources/chained_upgrade.xml')
+        # Trigger upgrade
+        api.select_version('myTuple')
+        view.execute()
+        # Assert new upgrade was created from the latest action
+        # 1 = original
+        # 2 = old upgrade
+        # 3 = new upgrade (should be the upgrade of 2)
+        vistrail = api.get_current_vistrail()
+        for a in vistrail.action_annotations:
+            if a.key == Vistrail.UPGRADE_ANNOTATION:
+                self.assertIn(a.action_id, [1,2])
+                if a.action_id == 1:
+                    self.assertEqual(int(a.value), 2)
+                if a.action_id == 2:
+                    self.assertEqual(int(a.value), 3)
+
+    def test_broken_upgrade(self):
+        # When upgrade is broken the controller should try to upgrade
+        # the previous action in the upgrade chain
+        from vistrails import api
+        view = api.open_vistrail_from_file(
+                vistrails.core.system.vistrails_root_directory() +
+                '/tests/resources/broken_upgrade.xml')
+        # Trigger upgrade
+        api.select_version('myTuple')
+        view.execute()
+        # Assert new upgrade was created from the first action
+        # 1 = original
+        # 2 = broken
+        # 3 = new (should be the upgrade of 1)
+        vistrail = api.get_current_vistrail()
+        for a in vistrail.action_annotations:
+            if a.key == Vistrail.UPGRADE_ANNOTATION:
+                self.assertEqual(a.action_id, 1)
+                self.assertEqual(int(a.value), 3)

--- a/vistrails/tests/resources/broken_upgrade.xml
+++ b/vistrails/tests/resources/broken_upgrade.xml
@@ -1,0 +1,23 @@
+<vistrail id="" name="" version="1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vistrails.org/vistrail.xsd">
+  <action date="2001-11-22 17:08:50" id="1" prevId="0" session="0" user="god">
+    <add id="0" objectId="0" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="0" name="Tuple" namespace="" package="edu.utah.sci.vistrails.basic" version="1.6" />
+    </add>
+    <add id="1" objectId="0" parentObjId="0" parentObjType="module" what="location">
+      <location id="0" x="0.0" y="0.0" />
+    </add>
+  </action>
+  <action date="2002-11-23 15:11:51" id="2" prevId="1" session="2" user="god">
+    <annotation id="0" key="__description__" value="Upgrade" />
+    <delete id="2" objectId="0" parentObjId="0" parentObjType="module" what="location" />
+    <delete id="3" objectId="0" parentObjId="" parentObjType="" what="module" />
+    <add id="4" objectId="1" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="1" name="BrokenUpgrade" namespace="" package="edu.utah.sci.vistrails.basic" version="10.0" />
+    </add>
+    <add id="5" objectId="1" parentObjId="1" parentObjType="module" what="location">
+      <location id="1" x="0.0" y="0.0" />
+    </add>
+  </action>
+  <actionAnnotation actionId="1" date="2002-09-12 14:41:53" id="0" key="__upgrade__" user="tommy" value="2" />
+  <actionAnnotation actionId="1" date="2002-09-12 14:42:20" id="1" key="__tag__" user="tommy" value="myTuple" />
+</vistrail>

--- a/vistrails/tests/resources/chained_upgrade.xml
+++ b/vistrails/tests/resources/chained_upgrade.xml
@@ -1,0 +1,23 @@
+<vistrail id="" name="" version="1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vistrails.org/vistrail.xsd">
+  <action date="2001-11-22 17:08:50" id="1" prevId="0" session="0" user="god">
+    <add id="0" objectId="0" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="0" name="Tuple" namespace="" package="edu.utah.sci.vistrails.basic" version="1.0" />
+    </add>
+    <add id="1" objectId="0" parentObjId="0" parentObjType="module" what="location">
+      <location id="0" x="0.0" y="0.0" />
+    </add>
+  </action>
+  <action date="2002-11-23 15:11:51" id="2" prevId="1" session="2" user="god">
+    <annotation id="0" key="__description__" value="Upgrade" />
+    <delete id="2" objectId="0" parentObjId="0" parentObjType="module" what="location" />
+    <delete id="3" objectId="0" parentObjId="" parentObjType="" what="module" />
+    <add id="4" objectId="1" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="1" name="Tuple" namespace="" package="edu.utah.sci.vistrails.basic" version="1.6" />
+    </add>
+    <add id="5" objectId="1" parentObjId="1" parentObjType="module" what="location">
+      <location id="1" x="0.0" y="0.0" />
+    </add>
+  </action>
+  <actionAnnotation actionId="1" date="2002-09-12 14:41:53" id="0" key="__upgrade__" user="tommy" value="2" />
+  <actionAnnotation actionId="1" date="2002-09-12 14:42:20" id="1" key="__tag__" user="tommy" value="myTuple" />
+</vistrail>

--- a/vistrails/tests/resources/looping_upgrades/pkg_a/__init__.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_a/__init__.py
@@ -1,0 +1,3 @@
+identifier = "org.vistrails.vistrails.tests.looping_fix.a"
+name = "LoopingFixA"
+version = "0.2"

--- a/vistrails/tests/resources/looping_upgrades/pkg_a/init.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_a/init.py
@@ -1,0 +1,23 @@
+from vistrails.core.modules.module_descriptor import ModuleDescriptor
+from vistrails.core.modules.vistrails_module import Module
+from vistrails.core.upgradeworkflow import UpgradeModuleRemap
+
+
+class A(Module):
+    _output_ports = [('result', 'basic:String')]
+
+    def compute(self):
+        self.set_output('result', 'A')
+
+
+_modules = [A]
+
+_upgrades = {'A' : [UpgradeModuleRemap(
+        # Upgrade for looping_fix.a 0.1 -> 0.2
+        # replaces module A with module B from looping_fix.b 0.1
+        '0.1', '0.2', '0.2',
+        new_module=ModuleDescriptor(
+                package='org.vistrails.vistrails.tests.looping_fix.b',
+                name='B',
+                namespace='',
+                package_version='0.1'))]}

--- a/vistrails/tests/resources/looping_upgrades/pkg_b/__init__.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_b/__init__.py
@@ -1,0 +1,3 @@
+identifier = "org.vistrails.vistrails.tests.looping_fix.b"
+name = "LoopingFixB"
+version = "0.2"

--- a/vistrails/tests/resources/looping_upgrades/pkg_b/init.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_b/init.py
@@ -1,0 +1,23 @@
+from vistrails.core.modules.module_descriptor import ModuleDescriptor
+from vistrails.core.modules.vistrails_module import Module
+from vistrails.core.upgradeworkflow import UpgradeModuleRemap
+
+
+class B(Module):
+    _output_ports = [('result', 'basic:String')]
+
+    def compute(self):
+        self.set_output('result', 'B')
+
+
+_modules = [B]
+
+_upgrades = {'B' : [UpgradeModuleRemap(
+        # Upgrade for looping_fix.b 0.1 -> 0.2
+        # replaces module B with module C from looping_fix.c 1.0
+        '0.1', '0.2', '0.2',
+        new_module=ModuleDescriptor(
+                package='org.vistrails.vistrails.tests.looping_fix.c',
+                name='C',
+                namespace='',
+                package_version='1.0'))]}

--- a/vistrails/tests/resources/looping_upgrades/pkg_c/__init__.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_c/__init__.py
@@ -1,0 +1,3 @@
+identifier = "org.vistrails.vistrails.tests.looping_fix.c"
+name = "LoopingFixC"
+version = "1.0"

--- a/vistrails/tests/resources/looping_upgrades/pkg_c/init.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_c/init.py
@@ -1,0 +1,11 @@
+from vistrails.core.modules.vistrails_module import Module
+
+
+class C(Module):
+    _output_ports = [('result', 'basic:String')]
+
+    def compute(self):
+        self.set_output('result', 'C')
+
+
+_modules = [C]

--- a/vistrails/tests/resources/looping_upgrades/pkg_x/__init__.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_x/__init__.py
@@ -1,0 +1,3 @@
+identifier = "org.vistrails.vistrails.tests.looping_fix.x"
+name = "LoopingFixX"
+version = "0.2"

--- a/vistrails/tests/resources/looping_upgrades/pkg_x/init.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_x/init.py
@@ -1,0 +1,23 @@
+from vistrails.core.modules.module_descriptor import ModuleDescriptor
+from vistrails.core.modules.vistrails_module import Module
+from vistrails.core.upgradeworkflow import UpgradeModuleRemap
+
+
+class X(Module):
+    _output_ports = [('result', 'basic:String')]
+
+    def compute(self):
+        self.set_output('result', 'X')
+
+
+_modules = [X]
+
+_upgrades = {'X' : [UpgradeModuleRemap(
+        # Upgrade for looping_fix.x 0.1 -> 0.2
+        # replaces module X with module Y from looping_fix.y 0.1
+        '0.1', '0.2', '0.2',
+        new_module=ModuleDescriptor(
+                package='org.vistrails.vistrails.tests.looping_fix.y',
+                name='Y',
+                namespace='',
+                package_version='0.1'))]}

--- a/vistrails/tests/resources/looping_upgrades/pkg_y/__init__.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_y/__init__.py
@@ -1,0 +1,3 @@
+identifier = "org.vistrails.vistrails.tests.looping_fix.y"
+name = "LoopingFixY"
+version = "0.2"

--- a/vistrails/tests/resources/looping_upgrades/pkg_y/init.py
+++ b/vistrails/tests/resources/looping_upgrades/pkg_y/init.py
@@ -1,0 +1,23 @@
+from vistrails.core.modules.module_descriptor import ModuleDescriptor
+from vistrails.core.modules.vistrails_module import Module
+from vistrails.core.upgradeworkflow import UpgradeModuleRemap
+
+
+class Y(Module):
+    _output_ports = [('result', 'basic:String')]
+
+    def compute(self):
+        self.set_output('result', 'Y')
+
+
+_modules = [Y]
+
+_upgrades = {'Y' : [UpgradeModuleRemap(
+        # Upgrade for looping_fix.y 0.1 -> 0.2
+        # replaces module Y with module X from looping_fix.x 0.1
+        '0.1', '0.2', '0.2',
+        new_module=ModuleDescriptor(
+                package='org.vistrails.vistrails.tests.looping_fix.x',
+                name='X',
+                namespace='',
+                package_version='0.1'))]}

--- a/vistrails/tests/resources/looping_upgrades/workflow.xml
+++ b/vistrails/tests/resources/looping_upgrades/workflow.xml
@@ -1,0 +1,26 @@
+<vistrail id="" name="" version="1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vistrails.org/vistrail.xsd">
+  <action date="2014-10-08 16:59:45" id="1" prevId="0" session="0" user="Remi">
+    <annotation id="0" key="__description__" value="Paste" />
+    <add id="0" objectId="0" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="0" name="A" namespace="" package="org.vistrails.vistrails.tests.looping_fix.a" version="0.1" />
+    </add>
+    <add id="1" objectId="0" parentObjId="0" parentObjType="module" what="location">
+      <location id="0" x="-31.0939597316" y="33.3825503356" />
+    </add>
+    <add id="2" objectId="1" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="1" name="StandardOutput" namespace="" package="org.vistrails.vistrails.basic" version="2.1.1" />
+    </add>
+    <add id="3" objectId="1" parentObjId="1" parentObjType="module" what="location">
+      <location id="1" x="53.0939597316" y="-53.3825503356" />
+    </add>
+    <add id="4" objectId="0" parentObjId="" parentObjType="" what="connection">
+      <connection id="0" />
+    </add>
+    <add id="5" objectId="1" parentObjId="0" parentObjType="connection" what="port">
+      <port id="1" moduleId="1" moduleName="StandardOutput" name="value" signature="(org.vistrails.vistrails.basic:Variant)" type="destination" />
+    </add>
+    <add id="6" objectId="0" parentObjId="0" parentObjType="connection" what="port">
+      <port id="0" moduleId="0" moduleName="A" name="result" signature="(org.vistrails.vistrails.basic:String)" type="source" />
+    </add>
+  </action>
+</vistrail>

--- a/vistrails/tests/resources/looping_upgrades/workflow2.xml
+++ b/vistrails/tests/resources/looping_upgrades/workflow2.xml
@@ -1,0 +1,26 @@
+<vistrail id="" name="" version="1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vistrails.org/vistrail.xsd">
+  <action date="2014-10-08 16:59:45" id="1" prevId="0" session="0" user="Remi">
+    <annotation id="0" key="__description__" value="Paste" />
+    <add id="0" objectId="0" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="0" name="X" namespace="" package="org.vistrails.vistrails.tests.looping_fix.x" version="0.1" />
+    </add>
+    <add id="1" objectId="0" parentObjId="0" parentObjType="module" what="location">
+      <location id="0" x="-31.0939597316" y="33.3825503356" />
+    </add>
+    <add id="2" objectId="1" parentObjId="" parentObjType="" what="module">
+      <module cache="1" id="1" name="StandardOutput" namespace="" package="org.vistrails.vistrails.basic" version="2.1.1" />
+    </add>
+    <add id="3" objectId="1" parentObjId="1" parentObjType="module" what="location">
+      <location id="1" x="53.0939597316" y="-53.3825503356" />
+    </add>
+    <add id="4" objectId="0" parentObjId="" parentObjType="" what="connection">
+      <connection id="0" />
+    </add>
+    <add id="5" objectId="1" parentObjId="0" parentObjType="connection" what="port">
+      <port id="1" moduleId="1" moduleName="StandardOutput" name="value" signature="(org.vistrails.vistrails.basic:Variant)" type="destination" />
+    </add>
+    <add id="6" objectId="0" parentObjId="0" parentObjType="connection" what="port">
+      <port id="0" moduleId="0" moduleName="X" name="result" signature="(org.vistrails.vistrails.basic:String)" type="source" />
+    </add>
+  </action>
+</vistrail>


### PR DESCRIPTION
Replaces https://github.com/VisTrails/VisTrails/tree/invalid-pipeline-hides-package-errors_/loops and #901.

Before,  handle_invalid_pipelines was called up to 2 times to resolve pipeline errors. But some cases will require 3 calls, as shown by 21708fabf50470467d5e0af2017ee3128b7e861e.

This pr makes handle_invalid_pipeline call iteself when needed so that it only needs to be called once.

This is based on, and includes,  #1164.