### PR TITLE
Rewrite tabledata with pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
       - python-matplotlib
       - python-mysqldb
       - python-numpy
+      - python-pandas
       - python-qt4
       - python-qt4-gl
       - python-qt4-sql

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Mako
 matplotlib
 mysql-python
 numpy
+pandas
 paramiko
 # PyQt<5.0
 pyth

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requirements = [
     # 'PyQt<5.0',
     'numpy',
     'scipy',
+    'pandas',
     'certifi',
     'backports.ssl_match_hostname',
     'file_archive>=0.6',

--- a/vistrails/packages/tabledata/__init__.py
+++ b/vistrails/packages/tabledata/__init__.py
@@ -42,6 +42,8 @@ extraction and conversion routines.
 """
 
 # ChangeLog:
+# 2016-04-07 -- 0.2.0
+#   * Move to pandas
 # 2014-05-29 -- 0.1.5
 #   * Updates JSON readers
 # 2014-02-03 -- 0.1.4

--- a/vistrails/packages/tabledata/__init__.py
+++ b/vistrails/packages/tabledata/__init__.py
@@ -77,3 +77,13 @@ def package_dependencies():
 def package_requirements():
     from vistrails.core.requirements import require_python_module
     require_python_module('csv')
+    require_python_module('pandas', {
+        'pip': 'pandas',
+        'linux-debian': 'python-pandas',
+        'linux-ubuntu': 'python-pandas',
+        'linux-fedora': 'python-pandas'})
+    require_python_module('numpy', {
+        'pip': 'numpy',
+        'linux-debian': 'python-numpy',
+        'linux-ubuntu': 'python-numpy',
+        'linux-fedora': 'numpy'})

--- a/vistrails/packages/tabledata/common.py
+++ b/vistrails/packages/tabledata/common.py
@@ -35,41 +35,14 @@
 
 from __future__ import division
 
-from vistrails.core.bundles.pyimport import py_import
+import numpy
+
 from vistrails.core.modules.basic_modules import List, ListType
 from vistrails.core.modules.config import ModuleSettings
 from vistrails.core.modules.output_modules import OutputModule, FileMode, \
     IPythonMode
 from vistrails.core.modules.vistrails_module import Module, ModuleError, \
     Converter
-
-
-_numpy = False
-
-def get_numpy(required=True):
-    """Tries to import numpy.
-
-    If `required` is False, don't ask again if the user already declined;
-    return None if numpy is not available.
-    If `required` is True, do ask to install, and raise ImportError if numpy
-    can't be set up.
-    """
-    global _numpy
-
-    if _numpy is False:
-        try:
-            _numpy = py_import(
-                    'numpy', {
-                        'pip': 'numpy',
-                        'linux-debian': 'python-numpy',
-                        'linux-ubuntu': 'python-numpy',
-                        'linux-fedora': 'numpy'},
-                    store_in_config=not required)
-        except ImportError:
-            _numpy = None
-    if _numpy is None and required:
-        raise ImportError("No module named numpy")
-    return _numpy
 
 
 class InternalModuleError(Exception):
@@ -101,8 +74,7 @@ class TableObject(object):
         If numeric=True, the data is returned as a numpy array if numpy is
         available, or as a list of floats.
         """
-        numpy = get_numpy(False)
-        if numeric and numpy is not None:
+        if numeric:
             return numpy.array(self._columns[i], dtype=numpy.float32)
         else:
             return self._columns[i]

--- a/vistrails/packages/tabledata/convert/convert_numpy.py
+++ b/vistrails/packages/tabledata/convert/convert_numpy.py
@@ -35,9 +35,9 @@
 
 from __future__ import division
 
-from vistrails.core.modules.vistrails_module import Module
+import numpy
 
-from ..common import get_numpy
+from vistrails.core.modules.vistrails_module import Module
 
 
 class Reshape(Module):
@@ -50,8 +50,6 @@ class Reshape(Module):
             ('value', '(org.vistrails.vistrails.basic:List)')]
 
     def compute(self):
-        numpy = get_numpy()
-
         array = self.get_input('array')
         shape = self.get_input('shape')
 

--- a/vistrails/packages/tabledata/identifiers.py
+++ b/vistrails/packages/tabledata/identifiers.py
@@ -37,4 +37,4 @@ from __future__ import division
 
 identifier = 'org.vistrails.vistrails.tabledata'
 name = 'tabledata'
-version = '0.1.6'
+version = '0.2.0'

--- a/vistrails/packages/tabledata/init.py
+++ b/vistrails/packages/tabledata/init.py
@@ -52,7 +52,7 @@ _modules = [common_modules,
             read_modules,
             write_modules]
 
-if get_package_manager().has_package( # pragma: no branch
+if get_package_manager().has_package(  # pragma: no branch
         'org.vistrails.vistrails.spreadsheet'):
     from .viewer import _modules as viewer_modules, TableToSpreadsheetMode
     _modules.append(viewer_modules)

--- a/vistrails/packages/tabledata/operations.py
+++ b/vistrails/packages/tabledata/operations.py
@@ -35,14 +35,12 @@
 
 from __future__ import division
 
+import numpy
 import re
 
 from vistrails.core.modules.vistrails_module import ModuleError
 
-from .common import get_numpy, TableObject, Table, \
-    choose_column, choose_columns
-
-# FIXME use pandas?
+from .common import TableObject, Table, choose_column, choose_columns
 
 
 def utf8(obj):
@@ -115,8 +113,7 @@ class JoinedTables(TableObject):
                     j = self.row_map[i]
                     result.append(column[j])
 
-        numpy = get_numpy(False)
-        if numeric and numpy is not None:
+        if numeric:
             result = numpy.array(result, dtype=numpy.float32)
         self.column_cache[(index, numeric)] = result
         return result
@@ -425,8 +422,6 @@ class TestJoin(unittest.TestCase):
     def test_join(self):
         """Test joining tables that have column names.
         """
-        import numpy
-
         with intercept_result(JoinTables, 'value') as results:
             self.assertFalse(execute([
                     ('BuildTable', identifier, [
@@ -646,8 +641,6 @@ class TestSelect(unittest.TestCase):
     def test_numeric(self):
         """Selects using the 'less-than' condition.
         """
-        import numpy
-
         self.do_select([
                 ('float_expr', [('String', '6'),
                                 ('String', '<='),

--- a/vistrails/packages/tabledata/read/read_csv.py
+++ b/vistrails/packages/tabledata/read/read_csv.py
@@ -36,9 +36,10 @@
 from __future__ import division
 
 import csv
+import numpy
 import operator
 
-from ..common import get_numpy, TableObject, Table, InternalModuleError
+from ..common import TableObject, Table, InternalModuleError
 
 
 def count_lines(fp):
@@ -125,9 +126,7 @@ class CSVTable(TableObject):
         if (index, numeric) in self.column_cache:
             return self.column_cache[(index, numeric)]
 
-        numpy = get_numpy(False)
-
-        if numeric and numpy is not None:
+        if numeric:
             result = numpy.loadtxt(
                     self.filename,
                     dtype=numpy.float32,

--- a/vistrails/packages/tabledata/read/read_excel.py
+++ b/vistrails/packages/tabledata/read/read_excel.py
@@ -35,10 +35,12 @@
 
 from __future__ import division
 
+import numpy
+
 from vistrails.core.bundles.pyimport import py_import
 from vistrails.core.modules.vistrails_module import ModuleError
 
-from ..common import get_numpy, TableObject, Table
+from ..common import TableObject, Table
 
 
 def get_xlrd():
@@ -75,15 +77,11 @@ class ExcelTable(TableObject):
         if (index, numeric) in self.column_cache:
             return self.column_cache[(index, numeric)]
 
-        numpy = get_numpy(False)
-
         result = [c.value for c in self.sheet.col(index)]
         if self.header_present:
             result = result[1:]
-        if numeric and numpy is not None:
+        if numeric:
             result = numpy.array(result, dtype=numpy.float32)
-        elif numeric:
-            result = [float(e) for e in result]
 
         self.column_cache[(index, numeric)] = result
         return result

--- a/vistrails/packages/tabledata/read/read_json.py
+++ b/vistrails/packages/tabledata/read/read_json.py
@@ -35,6 +35,8 @@
 
 from __future__ import division
 
+import numpy
+
 try:
     import simplejson as json
 except ImportError:
@@ -142,7 +144,6 @@ class TestJSON(unittest.TestCase):
             (table,), (count,), names = results
             self.assertEqual(count, 4)
 
-            import numpy
             if has_names:
                 self.assertEqual(names, [table.names])
                 self.assertEqual(table.names[0], 'key')
@@ -195,7 +196,6 @@ class TestJSON(unittest.TestCase):
             (table,), (count,), names = results
             self.assertEqual(count, 3)
 
-            import numpy
             if nb == 0:
                 self.assertEqual(names, [table.names])
                 self.assertEqual(set(table.names),

--- a/vistrails/packages/tabledata/read/read_numpy.py
+++ b/vistrails/packages/tabledata/read/read_numpy.py
@@ -35,9 +35,9 @@
 
 from __future__ import division
 
-from vistrails.core.modules.vistrails_module import Module
+import numpy
 
-from ..common import get_numpy
+from vistrails.core.modules.vistrails_module import Module
 
 
 class NumPyArray(Module):
@@ -75,7 +75,6 @@ class NumPyArray(Module):
     @classmethod
     def get_format(cls, format):
         if cls._format_map is None:
-            numpy = get_numpy()
             cls._format_map = dict(
                        npy = cls.NPY_FMT,
 
@@ -105,8 +104,6 @@ class NumPyArray(Module):
             ('value', '(org.vistrails.vistrails.basic:List)')]
 
     def compute(self):
-        numpy = get_numpy()
-
         filename = self.get_input('file').name
         if self.has_input('datatype'):
             dtype = NumPyArray.get_format(self.get_input('datatype'))

--- a/vistrails/packages/tabledata/write/write_numpy.py
+++ b/vistrails/packages/tabledata/write/write_numpy.py
@@ -1,8 +1,9 @@
 from __future__ import division
 
+import numpy
+
 from vistrails.core.modules.vistrails_module import Module
 
-from ..common import get_numpy
 from ..read.read_numpy import NumPyArray
 
 
@@ -22,8 +23,6 @@ class WriteNumPy(Module):
     _output_ports = [('file', '(org.vistrails.vistrails.basic:File)')]
 
     def compute(self):
-        numpy = get_numpy()
-
         array = self.get_input('array')
         if not isinstance(array, numpy.ndarray):
             array = numpy.array(array)
@@ -79,7 +78,6 @@ class WriteNumpyTestCase(unittest.TestCase):
     def test_npy_numpy(self):
         """Uses WriteNumPy to write an array in .NPY format.
         """
-        import numpy
         from vistrails.tests.utils import execute, intercept_result
         from ..identifiers import identifier
         with intercept_result(WriteNumPy, 'file') as results:


### PR DESCRIPTION
There is no real reason not to use pandas. I'm not considering automatic wrapping (there are few concepts and the API is more human- than machine-friendly).

This would make all tabledata into numpy arrays. Needs to integrate efficiently with streaming in new interpreter.

JSON should certainly be separate, [jq](https://stedolan.github.io/jq/) seems like a cool model for massaging it.