### PR TITLE
PyQt4 require API v2

### DIFF
--- a/vistrails/core/requirements.py
+++ b/vistrails/core/requirements.py
@@ -38,6 +38,7 @@
 runtime components such as binaries, libraries, other python modules, etc."""
 from __future__ import division
 
+import os
 import sys
 
 import vistrails.core.bundles.installbundle
@@ -95,3 +96,42 @@ class MissingRequirement(Exception):
     def __str__(self):
         return "Missing Requirement: %s" % self.requirement
 
+##############################################################################
+
+def setNewPyQtAPI():
+    import sip
+    # We now use the new PyQt API - IPython needs it
+    sip.setapi('QString', 2)
+    sip.setapi('QVariant', 2)
+
+
+def qt_available():
+    try:
+        require_python_module('sip')
+        setNewPyQtAPI()
+        require_python_module('PyQt4.QtGui')
+        require_python_module('PyQt4.QtOpenGL')
+    except MissingRequirement:
+        return False
+    else:
+        return True
+
+
+def require_pyqt4_api2():
+    # Forces the use of PyQt4 (avoid PySide even if installed)
+    # This is necessary at least for IPython
+    if os.environ.get('QT_API', None) not in (None, 'pyqt'):
+        sys.stderr.write("Warning: QT_API was set to %r, changing to 'pyqt'\n" %
+                         os.environ['QT_API'])
+    os.environ['QT_API'] = 'pyqt'
+
+    if not qt_available():
+        from vistrails.gui.bundles.installbundle import install
+        r = install({
+            'linux-debian': ['python-qt4', 'python-qt4-gl', 'python-qt4-sql'],
+            'linux-ubuntu': ['python-qt4', 'python-qt4-gl', 'python-qt4-sql'],
+            'linux-fedora': ['PyQt4'],
+            'pip': ['PyQt<5.0']})
+        if not r:
+            raise MissingRequirement('PyQt4')
+        setNewPyQtAPI()

--- a/vistrails/gui/requirements.py
+++ b/vistrails/gui/requirements.py
@@ -36,46 +36,7 @@
 
 from __future__ import division
 
-import os
-import sys
-
-from vistrails.core.requirements import MissingRequirement, require_python_module
+from vistrails.core.requirements import qt_available, require_pyqt4_api2
 
 
-def setNewPyQtAPI():
-    import sip
-    # We now use the new PyQt API - IPython needs it
-    sip.setapi('QString', 2)
-    sip.setapi('QVariant', 2)
-
-
-def qt_available():
-    try:
-        require_python_module('sip')
-        setNewPyQtAPI()
-        require_python_module('PyQt4.QtGui')
-        require_python_module('PyQt4.QtOpenGL')
-    except MissingRequirement:
-        return False
-    else:
-        return True
-
-
-def require_pyqt4_api2():
-    # Forces the use of PyQt4 (avoid PySide even if installed)
-    # This is necessary at least for IPython
-    if os.environ.get('QT_API', None) not in (None, 'pyqt'):
-        sys.stderr.write("Warning: QT_API was set to %r, changing to 'pyqt'\n" %
-                         os.environ['QT_API'])
-    os.environ['QT_API'] = 'pyqt'
-
-    if not qt_available():
-        from vistrails.gui.bundles.installbundle import install
-        r = install({
-            'linux-debian': ['python-qt4', 'python-qt4-gl', 'python-qt4-sql'],
-            'linux-ubuntu': ['python-qt4', 'python-qt4-gl', 'python-qt4-sql'],
-            'linux-fedora': ['PyQt4'],
-            'pip': ['PyQt<5.0']})
-        if not r:
-            raise MissingRequirement('PyQt4')
-        setNewPyQtAPI()
+__all__ = ['qt_available', 'require_pyqt4_api2']

--- a/vistrails/packages/dialogs/__init__.py
+++ b/vistrails/packages/dialogs/__init__.py
@@ -53,3 +53,8 @@ def package_dependencies():
         return ['org.vistrails.vistrails.spreadsheet']
     else:
         return []
+
+
+def package_requirements():
+    from vistrails.core.requirements import require_pyqt4_api2
+    require_pyqt4_api2()

--- a/vistrails/packages/parallelflow/engine_manager.py
+++ b/vistrails/packages/parallelflow/engine_manager.py
@@ -45,15 +45,16 @@ from IPython.utils.path import get_ipython_dir, locate_profile
 from IPython.parallel import Client
 from IPython.parallel import error
 
+import vistrails.core.requirements
 from vistrails.core.system import vistrails_root_directory
 
 
-try:
-    from PyQt4 import QtCore, QtGui
-except ImportError:
-    qt_available = False
-else:
+if vistrails.core.requirements.qt_available():
     qt_available = True
+
+    from PyQt4 import QtCore, QtGui
+else:
+    qt_available = False
 
 
 class ProfileItem(QtGui.QListWidgetItem):

--- a/vistrails/packages/pythonCalcQt/__init__.py
+++ b/vistrails/packages/pythonCalcQt/__init__.py
@@ -45,10 +45,17 @@ core/modules/vistrails_module.py.
 
 from __future__ import division
 
+
 identifier = 'org.vistrails.vistrails.pythoncalcqt'
 name = 'PythonCalcQt'
 version = '0.0.2'
 old_identifiers = ['edu.utah.sci.vistrails.pythoncalcqt']
 
+
 def package_dependencies():
     return ['org.vistrails.vistrails.pythoncalc']
+
+
+def package_requirements():
+    from vistrails.core.requirements import require_pyqt4_api2
+    require_pyqt4_api2()

--- a/vistrails/packages/qgis/__init__.py
+++ b/vistrails/packages/qgis/__init__.py
@@ -35,11 +35,12 @@
 ###############################################################################
 from __future__ import division
 
-import vistrails.core
+
 identifier = 'org.vistrails.vistrails.qgis'
 version = '0.0.2'
 name = "QGIS"
 old_identifiers = ['edu.utah.sci.vistrails.qgis']
+
 
 def package_dependencies():
     import vistrails.core.packagemanager
@@ -49,3 +50,7 @@ def package_dependencies():
     else:
         return []
 
+
+def package_requirements():
+    from vistrails.core.requirements import require_pyqt4_api2
+    require_pyqt4_api2()

--- a/vistrails/packages/spreadsheet/__init__.py
+++ b/vistrails/packages/spreadsheet/__init__.py
@@ -40,3 +40,8 @@ from identifiers import *
 
 # This must be here because of VisTrails protocol
 from .spreadsheet_config import configuration
+
+
+def package_requirements():
+    from vistrails.gui.requirements import require_pyqt4_api2
+    require_pyqt4_api2()

--- a/vistrails/packages/vtk/__init__.py
+++ b/vistrails/packages/vtk/__init__.py
@@ -41,7 +41,9 @@ the world. http://www.vtk.org"""
 from __future__ import division
 
 from identifiers import *
-import vistrails.core
+from vistrails.core import debug
+from vistrails.core.requirements import MissingRequirement
+
 
 def package_dependencies():
     import vistrails.core.packagemanager
@@ -58,7 +60,10 @@ def package_requirements():
             'linux-debian': 'python-vtk',
             'linux-ubuntu': 'python-vtk',
             'linux-fedora': 'vtk-python'})
-    if not python_module_exists('PyQt4'):
-        from vistrails.core import debug
+
+    from vistrails.gui.requirements import require_pyqt4_api2
+    try:
+        require_pyqt4_api2()
+    except MissingRequirement:
         debug.warning('PyQt4 is not available. There will be no interaction '
                       'between VTK and the spreadsheet.')


### PR DESCRIPTION
Fixes #1200 

Importing PyQt4 directly might enable API v1 which can't be changed after that, if not running the VisTrais GUI (which sets API to v2 before importing packages).