### PR TITLE
Improve configurable directories

### DIFF
--- a/vistrails/core/configuration.py
+++ b/vistrails/core/configuration.py
@@ -100,7 +100,6 @@ multithread: Server will start a thread for each request
 outputDirectory: Directory in which to place output files
 outputPipelineGraph: Output the workflow graph as an image
 outputVersionTree: Output the version tree as an image
-packageDir: System packages directory
 parameterExploration: Run parameter exploration instead of workflow
 parameters: List of parameters to use when running workflow
 port: The port for the database to load the vistrail from
@@ -347,11 +346,6 @@ outputVersionTree: Boolean
 
     Output the version tree as an image.
 
-packageDir: Path
-
-    The directory to look for VisTrails core packages (use
-    userPackageDir for user-defined packages).
-
 parameterExploration: Boolean
 
     Open and execute parameter exploration specified by the
@@ -560,7 +554,7 @@ user: String
 
     The username for the database to load the vistrail from.
 
-userPackageDir: Boolean
+userPackageDir: Path
 
     The location for user-installed packages (defaults to
     ~/.vistrails/userpackages).
@@ -775,7 +769,6 @@ base_config = {
                  ConfigPath, flag="-S"),
      ConfigField('subworkflowsDir', "subworkflows", ConfigPath),
      ConfigField('dataDir', None, ConfigPath),
-     ConfigField('packageDir', None, ConfigPath),
      ConfigField('userPackageDir', "userpackages", ConfigPath),
      ConfigField('fileDir', None, ConfigPath),
      ConfigField('logDir', "logs", ConfigPath),
@@ -1560,7 +1553,7 @@ class ConfigurationObject(DBConfiguration):
 #         'minMemory': (None, int),
 #         'multiHeads': False,
 #         'nologger': False,
-#         'packageDirectory': (None, str),
+#         'packageDir': (None, str),
 #         'pythonPrompt': False,
 #         'recentVistrailList': (None, str),
 #         'repositoryLocalPath': (None, str),

--- a/vistrails/core/packagemanager.py
+++ b/vistrails/core/packagemanager.py
@@ -109,8 +109,6 @@ class PackageManager(object):
         # Imports standard packages directory
         conf = self._startup.temp_configuration
         old_sys_path = copy.copy(sys.path)
-        if conf.check('packageDirectory'):
-            sys.path.insert(0, conf.packageDirectory)
         try:
             import vistrails.packages
         except ImportError:

--- a/vistrails/core/packagemanager.py
+++ b/vistrails/core/packagemanager.py
@@ -822,8 +822,9 @@ class PackageManager(object):
         # Finds user packages
         userpackages = self.import_user_packages_module()
         if userpackages is not None:
-            search(os.path.dirname(userpackages.__file__),
-                   prefix='userpackages.')
+            for path in userpackages.__path__:
+                search(path,
+                       prefix='userpackages.')
 
         # Finds plugin packages
         try:

--- a/vistrails/core/startup.py
+++ b/vistrails/core/startup.py
@@ -250,6 +250,8 @@ class VistrailsStartup(DBStartup):
 
     def setup_init_file(self, dir_name):
         name = os.path.join(dir_name, '__init__.py')
+        if os.path.exists(name):
+            return
         try:
             f = open(name, 'w')
             f.write('pass\n')

--- a/vistrails/core/system/__init__.py
+++ b/vistrails/core/system/__init__.py
@@ -122,17 +122,17 @@ __rootDir = os.path.realpath(os.path.join(_thisDir,
                                           '..',
                                           '..'))
 
-__dataDir = os.path.realpath(os.path.join(__rootDir,
-                                          'data'))
-__fileDir = os.path.realpath(os.path.join(__rootDir,
-                                          '..','examples'))
+__dataDir = None
+__fileDir = None
 
-if systemType in ['Darwin'] and not os.path.exists(__fileDir):
+__examplesDir = os.path.realpath(os.path.join(__rootDir,
+                                              '..','examples'))
+
+if systemType in ['Darwin'] and not os.path.exists(__examplesDir):
     # Assume we are running from py2app
-    __fileDir = os.path.realpath(os.path.join(__rootDir,
-                                              '/'.join(['..']*6),'examples'))
-
-__examplesDir = __fileDir
+    __examplesDir = os.path.realpath(os.path.join(__rootDir,
+                                                  '/'.join(['..']*6),
+                                                  'examples'))
 
 __defaultFileType = '.vt'
 
@@ -227,6 +227,12 @@ def vistrails_file_directory():
     Returns current vistrails file directory
 
     """
+    global __fileDir
+    if __fileDir is None:
+        from vistrails.core.configuration import get_vistrails_configuration
+        __fileDir = get_vistrails_configuration().check('fileDir')
+        if not __fileDir:
+            __fileDir = vistrails_examples_directory()
     return __fileDir
 
 def vistrails_examples_directory():
@@ -241,6 +247,12 @@ def vistrails_data_directory():
     Returns vistrails data directory
 
     """
+    global __dataDir
+    if __dataDir is None:
+        from vistrails.core.configuration import get_vistrails_configuration
+        __dataDir = get_vistrails_configuration().check('dataDir')
+        if not __dataDir:
+            __dataDir = os.path.join(vistrails_root_directory(), 'data')
     return __dataDir
 
 def vistrails_default_file_type():

--- a/vistrails/db/versions/v1_0_4/translate/v1_0_3.py
+++ b/vistrails/db/versions/v1_0_4/translate/v1_0_3.py
@@ -277,7 +277,7 @@ def translateStartup(_startup):
          'temporaryDirectory': 'temporaryDir',
          'dataDirectory': 'dataDir',
          'fileDirectory': 'fileDir',
-         'packageDirectory': 'packageDir',
+         'packageDirectory': None,
 
          }
 

--- a/vistrails/gui/extras/core/db/locator.py
+++ b/vistrails/gui/extras/core/db/locator.py
@@ -150,8 +150,6 @@ def get_load_file_locator_from_gui(parent, obj_type):
         return None
     filename = os.path.abspath(str(QtCore.QFile.encodeName(fileName)))
     dirName = os.path.dirname(filename)
-    setattr(get_vistrails_persistent_configuration(), 'fileDir', dirName)
-    setattr(get_vistrails_configuration(), 'fileDir', dirName)
     vistrails.core.system.set_vistrails_file_directory(dirName)
     return FileLocator(filename)
 
@@ -192,8 +190,6 @@ def get_save_file_locator_from_gui(parent, obj_type, locator=None):
         if msg.exec_() == QtGui.QMessageBox.No:
             return None
     dirName = os.path.dirname(f)
-    setattr(get_vistrails_persistent_configuration(), 'fileDir', dirName)
-    setattr(get_vistrails_configuration(), 'fileDir', dirName)
     vistrails.core.system.set_vistrails_file_directory(dirName)
     return FileLocator(f)
    

--- a/vistrails/gui/vistrail_controller.py
+++ b/vistrails/gui/vistrail_controller.py
@@ -972,7 +972,6 @@ class VistrailController(QtCore.QObject, BaseController):
         if not dir_name:
             return None
         dir_name = os.path.abspath(str(dir_name))
-        setattr(get_vistrails_configuration(), 'fileDir', dir_name)
         vistrails.core.system.set_vistrails_file_directory(dir_name)
         return dir_name
 


### PR DESCRIPTION
* Don't re-create `__init__.py` files in dotVistrails directories if they exist (makes next item work)
* Use userpackages.__path__, allowing the user to use `__path__.append(...)` in `userpackages/__init__.py` to specify alternate locations where userpackages can be found
* Remove `packageDir` setting, since it doesn't work (Python never looked there, because the import system relies on `vistrails.__path__` only)
* Fix the `dataDir` and `fileDir` configuration settings; `core.system` now uses that on startup instead of the hardcoded defaults (once a file has been saved, the global variables are updated however, and the save folder will be used until VisTrails is restarted)

Fixes #1208