### PR TITLE
Allow non-plaintext module documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 addons:
   apt:
     packages:
+      - python-docutils
       - python-matplotlib
       - python-mysqldb
       - python-numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 backports.ssl_match_hostname
 certifi
+docutils
 dulwich
 IPython
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requirements = [
     'scipy',
     'certifi',
     'backports.ssl_match_hostname',
+    'docutils',
     'file_archive>=0.6',
     'python-dateutil',
     'requests',

--- a/vistrails/core/modules/module_descriptor.py
+++ b/vistrails/core/modules/module_descriptor.py
@@ -39,6 +39,7 @@ import copy
 import pydoc
 
 from vistrails.core import debug
+from vistrails.core.bundles import py_import
 from vistrails.core.utils import VistrailsInternalError
 from vistrails.core.vistrail.port_spec import PortSpec
 import vistrails.core.modules.module_registry
@@ -331,7 +332,21 @@ class ModuleDescriptor(DBModuleDescriptor):
             doc = docstring
         if doc:
             if format == 'html':
-                return pydoc.html.markup(doc, pydoc.html.preformat)
+                try:
+                    py_import('docutils',
+                              {'pip': 'docutils',
+                               'linux-debian': 'python-docutils',
+                               'linux-ubuntu': 'python-docutils',
+                               'linux-fedora': 'python-docutils'},
+                              True)
+                except ImportError:
+                    return pydoc.html.markup(doc, pydoc.html.preformat)
+                else:
+                    from docutils.core import publish_string
+
+                    if isinstance(doc, bytes):
+                        doc = doc.decode('utf-8', 'replace')
+                    return publish_string(doc, writer_name='html')
             return doc
         return None
 

--- a/vistrails/core/modules/module_descriptor.py
+++ b/vistrails/core/modules/module_descriptor.py
@@ -303,19 +303,37 @@ class ModuleDescriptor(DBModuleDescriptor):
             return None
         return (self._left_fringe, self._right_fringe)
 
-    def module_documentation(self, module=None):
-        doc = pydoc.getdoc(self.module)
-        if hasattr(self.module, 'get_documentation'):
-            try:
-                doc = self.module.get_documentation(doc, module)
-            except Exception, e:
-                debug.unexpected_exception(e)
-                debug.critical("Exception calling get_documentation on %r" %
-                               self.module,
-                               e)
-                doc = doc or "(Error getting documentation)"
-        doc = doc or "(No documentation available)"
-        return doc
+    def module_documentation(self, module=None, format='text', fallback=True):
+        if self.module is None:
+            return None
+
+        docstring = pydoc.getdoc(self.module)
+
+        def getdoc(method):
+            if hasattr(self.module, method):
+                try:
+                    return getattr(self.module, method)(docstring, module)
+                except Exception, e:
+                    debug.unexpected_exception(e)
+                    debug.critical("Exception calling %s on %r" % (
+                                       method,
+                                       self.module),
+                                   e)
+            return None
+
+        doc = getdoc('get_documentation_%s' % format)
+        if doc:
+            return doc
+        if not (format == 'text' or fallback):
+            return None
+        doc = getdoc('get_documentation')
+        if not doc:
+            doc = docstring
+        if doc:
+            if format == 'html':
+                return pydoc.html.markup(doc, pydoc.html.preformat)
+            return doc
+        return None
 
     def module_package(self):
         return self.identifier

--- a/vistrails/gui/application_server.py
+++ b/vistrails/gui/application_server.py
@@ -212,10 +212,12 @@ class RequestHandler(object):
                             module.package,
                             module.name,
                             module.namespace)
+                    mod_info = {'name': module.name,
+                                'package': module.package}
                     documentation = descriptor.module_documentation(module)
-                    result.append({'name':module.name,
-                                              'package':module.package,
-                                              'documentation':documentation})
+                    if documentation:
+                        mod_info['documentation'] = documentation
+                    result.append(mod_info)
                 return (result, 1)
             else:
                 result = "Pipeline was not materialized"

--- a/vistrails/gui/module_documentation.py
+++ b/vistrails/gui/module_documentation.py
@@ -66,15 +66,9 @@ class QModuleDocumentation(QtGui.QDialog, QVistrailsPaletteInterface):
         self.layout().addWidget(self.name_label)
         self.package_label = QtGui.QLabel("")
         self.layout().addWidget(self.package_label)
-        # self.closeButton = QtGui.QPushButton('Ok', self)
-        self.textEdit = QtGui.QTextEdit(self)
+        self.textEdit = QtGui.QTextBrowser(self)
         self.layout().addWidget(self.textEdit, 1)
-        self.textEdit.setReadOnly(True)
-        self.textEdit.setTextCursor(QtGui.QTextCursor(self.textEdit.document()))
-        # self.layout().addWidget(self.closeButton)
-        # self.connect(self.closeButton, QtCore.SIGNAL('clicked(bool)'), 
-        #              self.close)
-        # self.closeButton.setShortcut('Enter')
+        self.textEdit.setOpenExternalLinks(True)
 
         self.update_descriptor()
 

--- a/vistrails/gui/module_documentation.py
+++ b/vistrails/gui/module_documentation.py
@@ -111,7 +111,13 @@ class QModuleDocumentation(QtGui.QDialog, QVistrailsPaletteInterface):
             self.name_label.setText("Module name: %s" % descriptor.name)
             self.package_label.setText("Module package: %s" % \
                                            descriptor.module_package())
-            self.textEdit.setText(descriptor.module_documentation(module))
+            documentation = descriptor.module_documentation(module,
+                                                            format='html')
+            if documentation:
+                self.textEdit.setHtml(documentation)
+            else:
+                self.textEdit.setHtml(
+                        "<em>(No documentation available)</em>")
 
     def activate(self):
         if self.isVisible() == False:

--- a/vistrails/packages/URL/init.py
+++ b/vistrails/packages/URL/init.py
@@ -368,22 +368,30 @@ class DownloadFile(Module):
     filesystem so as to not re-download unchanged files.
 
     Recognized URL schemes are:
-        http://...
-        https://...
-        ftp://...
-        ssh://user[:password]@host[:port]/absolute/path
-            Examples:
-                ssh://john@vistrails.nyu.edu/home/john/example.txt
-                ssh://eve:my%20secret@google.com/tmp/test%20file.bin
-            Note that both password and path are url-encoded, that the path
-            is absolute, and that the username must be specified
-        scp://[user@]host:path
-            Examples:
-                scp://john@vistrails.nyu.edu:files/test.txt
-                scp://poly.edu:/tmp/test.bin
-            Note that nothing is url encoded, that the path can be relative
-            (to the user's home directory) and that no username or port can
-            be specified
+      - `http://...`
+      - `https://...`
+      - `ftp://...`
+      - `ssh://user[:password]@host[:port]/absolute/path`
+
+        Examples:
+
+        - `ssh://john@vistrails.nyu.edu/home/john/example.txt`
+        - `ssh://eve:my%20secret@google.com/tmp/test%20file.bin`
+
+        Note that both password and path are url-encoded, that the path
+        is absolute, and that the username must be specified
+      - `scp://[user@]host:path`
+
+        Examples:
+
+        - `scp://john@vistrails.nyu.edu:files/test.txt`
+        - `scp://poly.edu:/tmp/test.bin`
+
+        Note that nothing is url encoded, that the path can be relative
+        (to the user's home directory) and that no username or port can
+        be specified
+
+    If `insecure` is set, an invalid TLS certificate will not cause an error.
     """
 
     def compute(self):
@@ -406,7 +414,9 @@ class DownloadFile(Module):
 
 
 class HTTPDirectory(Module):
-    """Downloads a whole directory recursively from a URL
+    """Downloads a whole directory recursively from a URL.
+
+    If `insecure` is set, an invalid TLS certificate will not cause an error.
     """
 
     def compute(self):
@@ -426,12 +436,32 @@ class HTTPDirectory(Module):
 
 
 class URLEncode(Module):
+    """Encode special characters to a format suitable for URLs.
+
+    This uses Python's `urllib.quote_plus()` function, which encodes special
+    characters as `%xx` escapes and a space ' ' with a plus sign '+'.
+
+    Example::
+
+    '~/abc def' -> '%7e/abc+def'
+    """
+
     def compute(self):
         value = self.get_input('string')
         self.set_output('encoded', urllib.quote_plus(value))
 
 
 class URLDecode(Module):
+    """Decode special characters formatted into a URL.
+
+    This uses Python's `urllib.unquote_plus()` function, which decodes '%xx'
+    escapes and replaces a plus sign '+' with a space ' '.
+
+    Example::
+
+    '%7e/abc+def' -> '~/abc def'
+    """
+
     def compute(self):
         encoded = self.get_input('encoded')
         self.set_output('string', urllib.unquote_plus(encoded))

--- a/vistrails/packages/controlflow/order.py
+++ b/vistrails/packages/controlflow/order.py
@@ -43,12 +43,12 @@ from vistrails.core.modules.vistrails_module import Module, InvalidOutput
 ## Order Operator
 
 class ExecuteInOrder(Module):
-    """
-    The Order Module alows the user to control which sink of a pair of
-    sinks ought to executed first.  Connect the "self" port of each
-    sink to the corresponding port.  Note that if you have more than
-    two sinks, you can string them together by using a string of Order
-    modules.
+    """Allows the user to control which sink of a pair of sinks ought to be
+    executed first.
+
+    Connect the "self" port of each sink to the corresponding port.
+    Note that if you have more than two sinks, you can string them together by
+    using a string of ExecuteInOrder modules.
     """
 
     def update_upstream(self):

--- a/vistrails/packages/controlflow/products.py
+++ b/vistrails/packages/controlflow/products.py
@@ -46,9 +46,12 @@ class ElementwiseProduct(Module):
     """This module does the product of two lists.
 
     If NumericalProduct is True, this will effectively compute the product of
-    each element, eg:
+    each element, eg::
+
         [1, 2, 3] x [3, -3, 1] = [3, -6, 3]
-    Else, it will make tuples, eg:
+
+    Else, it will make tuples, eg::
+
         [1, 2, 3] x [3, -3, 1] = [(1, 3), (2, -3), (3, 1)]
     """
 
@@ -102,6 +105,17 @@ class Cross(Module):
 
 class CartesianProduct(Module):
     """This module does the cartesian product of two lists.
+
+    If CombineTuple is True (the default), existing tuples will be
+    concatenated instead of put inside a new tuple, eg:
+
+      - with CombineTuple (default)::
+
+        [(1, 2)], [3, 4] -> [(1, 2, 3), (1, 2, 4)]
+
+      - without::
+
+        [(1, 2)], [3, 4] -> [((1, 2), 3), ((1, 2), 4)]
     """
 
     def compute(self):

--- a/vistrails/packages/controlflow/utils.py
+++ b/vistrails/packages/controlflow/utils.py
@@ -57,7 +57,7 @@ class Map(FoldWithModule):
 
 
 class Filter(FoldWithModule):
-    """A Filter module, that returns in a list only the results that satisfy a
+    """A Filter module, that returns in a list only the elements that satisfy a
     condition."""
 
     def setInitialValue(self):

--- a/vistrails/packages/dialogs/continue_prompt.py
+++ b/vistrails/packages/dialogs/continue_prompt.py
@@ -64,6 +64,13 @@ class PromptWindow(QtGui.QDialog):
 
 
 class PromptIsOkay(Module):
+    """Ask the user to confirm an intermediate result looks okay.
+
+    When this module is executed, a dialog window will be shown with a single
+    spreadsheet cell and the given message. Execution will continue if the user
+    confirms. If the user clicks 'cancel', execution will stop.
+    """
+
     _input_ports = [('label', basic_modules.String,
                      {'optional': True}),
                     ('carry_on', basic_modules.Boolean,

--- a/vistrails/packages/dialogs/init.py
+++ b/vistrails/packages/dialogs/init.py
@@ -55,6 +55,16 @@ class Dialog(Module):
 
 
 class TextDialog(Dialog):
+    """Ask the user to provide a string interactively.
+
+    When this module is executed, a dialog window will be shown with the given
+    message. Execution will continue with the user-provided string as the
+    output once the user confirms. If the user clicks 'cancel', execution will
+    stop.
+
+    Optionally, the answer from the user can be cached for this session.
+    """
+
     _input_ports = [('label', basic_modules.String,
                      {'optional': True, 'defaults': "['']"}),
                     ('default', basic_modules.String,
@@ -83,6 +93,17 @@ class TextDialog(Dialog):
 
 
 class PasswordDialog(TextDialog):
+    """Ask the user to provide a password interactively.
+
+    The input will be hidden by stars as is customary for password inputs.
+
+    When this module is executed, a dialog window will be shown with the given
+    message. Execution will continue with the user-provided string as the
+    output once the user confirms. If the user clicks 'cancel', execution will
+    stop.
+
+    Optionally, the answer from the user can be cached for this session.
+    """
     _input_ports = [('label', basic_modules.String,
                      {'optional': True, 'defaults': "['Password']"})]
 
@@ -90,6 +111,15 @@ class PasswordDialog(TextDialog):
 
 
 class YesNoDialog(Dialog):
+    """Ask the user to answer "yes" or "no.
+
+    When this module is executed, a dialog window will be shown with the given
+    message and two buttons. Execution will continue with the boolean answer as
+    an output once the user responds.
+
+    Optionally, the answer from the user can be cached for this session.
+    """
+
     _input_ports = [('label', basic_modules.String,
                      {'optional': True, 'defaults': "['Yes/No?']"})]
     _output_ports = [('result', basic_modules.Boolean)]

--- a/vistrails/packages/gmaps/gmap_cell.py
+++ b/vistrails/packages/gmaps/gmap_cell.py
@@ -48,8 +48,7 @@ from .utils import *
 
 class GMapCell(SpreadsheetCell, OptionsMixin):
     """
-    GMapCell is a custom Module to view TabularData geographically
-    
+    Renders TabularData geographically on the spreadsheet.
     """
 
     SPECS = [('zoom', None, True), 

--- a/vistrails/packages/gmaps/vis.py
+++ b/vistrails/packages/gmaps/vis.py
@@ -123,6 +123,8 @@ class GMapVis(Module, OptionsMixin):
         return (positions, center)
 
 class GMapMarkers(GMapVis, TitlesMixin):
+    """Turns tabular data into markers to be shown on a map.
+    """
     TEMPLATE = Template("""
   var positions = $marker_data;
   var options = $marker_options;
@@ -173,6 +175,8 @@ class GMapValueVis(GMapVis):
         return value_col
 
 class GMapCircles(GMapValueVis):
+    """Turns tabular data into circles of different sizes to be shown on a map.
+    """
     TEMPLATE = Template("""
   var data = $circle_data;
   
@@ -210,6 +214,8 @@ class GMapCircles(GMapValueVis):
         self.set_output("self", vis_data)
 
 class GMapSymbols(GMapValueVis, TitlesMixin):
+    """Turns tabular data into different symbols to be shown on a map.
+    """
     TEMPLATE = Template("""
   var data = $symbol_data;
   var titles = $symbol_titles;
@@ -316,6 +322,8 @@ class GMapSymbols(GMapValueVis, TitlesMixin):
         self.set_output("self", vis_data)
 
 class GMapHeatmap(GMapValueVis):
+    """Turns tabular data into a heatmap layer to be shown on a map.
+    """
     TEMPLATE = Template("""
   var data = $heatmap_data;
   var options = $heatmap_options;

--- a/vistrails/packages/mongodb/init.py
+++ b/vistrails/packages/mongodb/init.py
@@ -134,13 +134,14 @@ class BaseCollectionOperation(Module):
         raise NotImplementedError
 
 
-_modules.append(BaseCollectionOperation)
+_modules.append((BaseCollectionOperation, {'abstract': True}))
 
 
-def collection_op(input_ports, output=None):
+def collection_op(input_ports, output=None, doc=None):
     def wrapper(func):
         dct = {'_input_ports': input_ports,
-               'collection_operation': func}
+               'collection_operation': func,
+               '__doc__': doc}
         if output:
             dct['_output_ports'] = [output]
             dct['collection_op_out'] = output[0]
@@ -149,64 +150,81 @@ def collection_op(input_ports, output=None):
     return wrapper
 
 
-@collection_op([('document', '(basic:Dictionary)')])
+@collection_op([('document', '(basic:Dictionary)')],
+               doc="Insert a single document into a collection.")
 def InsertOne(self, coll):
     coll.insert_one(self.get_input('document'))
 
 
 @collection_op([('filter', '(basic:Dictionary)'),
-                ('document', '(basic:Dictionary)')])
+                ('document', '(basic:Dictionary)')],
+               doc="Replace a single document matching the filter.")
 def ReplaceOne(self, coll):
     coll.replace_one(self.get_input('filter'), self.get_input('document'))
 
 
 @collection_op([('filter', '(basic:Dictionary)'), ('document', '(basic:Dictionary)'),
                 ('insert_if_nomatch', '(basic:Boolean)',
-                 {'optional': True, 'defaults': ['True']})])
+                 {'optional': True, 'defaults': ['True']})],
+               doc="Update one document matching the selector.")
 def UpdateOne(self, coll):
     coll.update_one(self.get_input('filter'),
                     self.get_input('document'),
                     upsert=self.get_input('insert_if_nomatch'))
 
 
-@collection_op([('filter', '(basic:Dictionary)')])
+@collection_op([('filter', '(basic:Dictionary)')],
+               doc="Delete a single document matching the filter.")
 def DeleteOne(self, coll):
     coll.delete_one(self.get_input('filter'))
 
 
-@collection_op([('filter', '(basic:Dictionary)')])
+@collection_op([('filter', '(basic:Dictionary)')],
+               doc="Delete one or more documents matching the filter.")
 def DeleteMany(self, coll):
     coll.delete_many(self.get_input('filter'))
 
 
 @collection_op([('pipeline', '(basic:List)')],
-               output=('results', '(basic:List)'))
+               output=('results', '(basic:List)'),
+               doc="Calculate aggregate values for the data in the "
+                   "collection.\n"
+                   "\n"
+                   "The pipeline is a list of operations. See the `aggregation"
+                   " pipeline operators <https://docs.mongodb.com/manual/ref"
+                   "erence/operator/aggregation-pipeline/>`__ for details.")
 def Aggregate(self, coll):
     return list(coll.aggregate(self.get_input('pipeline')))
 
 
 @collection_op([('filter', '(basic:Dictionary)'),
                 ('limit', '(basic:Integer)', {'optional': True})],
-               output=('results', '(basic:List)'))
+               output=('results', '(basic:List)'),
+               doc="Query the database.")
 def Find(self, coll):
     return list(coll.find(self.get_input('filter'),
                           limit=self.force_get_input('limit', 0)))
 
 
 @collection_op([('filter', '(basic:Dictionary)')],
-               output=('document', '(basic:Dictionary)'))
+               output=('document', '(basic:Dictionary)'),
+               doc="Get a single document from the database.")
 def FindOne(self, coll):
     return coll.find_one(self.get_input('filter'))
 
 
 @collection_op([('filter', '(basic:Dictionary)')],
-               output=('old_document', '(basic:Dictionary)'))
+               output=('old_document', '(basic:Dictionary)'),
+               doc="Finds a single document and deletes it, returning the "
+                   "document.")
 def FindOneAndDelete(self, coll):
     return coll.find_one_and_delete(self.get_input('filter'))
 
 
 @collection_op([('filter', '(basic:Dictionary)'), ('document', '(basic:Dictionary)')],
-               output=('old_document', '(basic:Dictionary)'))
+               output=('old_document', '(basic:Dictionary)'),
+               doc="Finds a single document and replaces it, returning the "
+                   "old document.")
 def FindOneAndReplace(self, coll):
     return coll.find_one_and_replace(self.get_input('filter'),
                                      self.get_input('document'))
@@ -214,20 +232,27 @@ def FindOneAndReplace(self, coll):
 
 @collection_op([('filter', '(basic:Dictionary)'),
                 ('update', '(basic:Dictionary)')],
-               output=('old_document', '(basic:Dictionary)'))
+               output=('old_document', '(basic:Dictionary)'),
+               doc="Finds a single document and updates it, returning the old "
+                   "document.")
 def FindOneAndUpdate(self, coll):
     return coll.find_one_and_update(self.get_input('filter'),
                                     self.get_input('update'))
 
 
 @collection_op([('filter', '(basic:Dictionary)', {'optional': True})],
-               output=('count', '(basic:Integer)'))
+               output=('count', '(basic:Integer)'),
+               doc="Get the number of documents in this collection, "
+                   "optionally matching a filter.")
 def Count(self, coll):
     return coll.count(self.force_get_input('filter'))
 
 
 @collection_op([('key', '(basic:String)'), ('filter', '(basic:Dictionary)')],
-               output=('results', '(basic:List)'))
+               output=('results', '(basic:List)'),
+               doc="Get a list of distinct values for `key` among all "
+                   "documents in this collection, or the ones matching the "
+                   "filter.")
 def Distinct(self, coll):
     return list(coll.distinct(self.get_input('key'), self.get_input('filter')))
 
@@ -235,7 +260,18 @@ def Distinct(self, coll):
 @collection_op([('key', '(basic:List)'), ('condition', '(basic:Dictionary)'),
                 ('initial', '(basic:Variant)'), ('reduce', '(basic:String)'),
                 ('finalize', '(basic:String)')],
-               output=('results', '(basic:List)'))
+               output=('results', '(basic:List)'),
+               doc="Perform a query similar to an SQL *group by* operation.\n"
+                   "\n"
+                   "Returns an array of grouped items.\n"
+                   "\n"
+                   "  - `key` is a list of keys to group by.\n"
+                   "  - `condition` specifies which documents to consider.\n"
+                   "  - `initial` is the initial value of the aggregation "
+                   "counter object.\n"
+                   "  - `reduce` is the aggregation function as JavaScript.\n"
+                   "  - `finalize` is the function to be called on each "
+                   "object in the output list.")
 def Group(self, coll):
     return list(coll.group(self.get_input('key'), self.get_input('condition'),
                            self.get_input('initial'), self.get_input('reduce'),
@@ -244,7 +280,15 @@ def Group(self, coll):
 
 @collection_op([('map', '(basic:String)'), ('reduce', '(basic:String)'),
                 ('out', '(basic:String)')],
-               output=('results', MongoCollection))
+               output=('results', MongoCollection),
+               doc="Perform a map/reduce operation on this collection.\n"
+                   "\n"
+                   "Returns a collection object containing the results of the "
+                   "operation.\n"
+                   "\n"
+                   "  - `map` is the map function as JavaScript.\n"
+                   "  - `reduce` is the reduce function as JavaScript.\n"
+                   "  - `out` is the output collection name.")
 def MapReduce(self, coll):
     return coll.map_reduce(self.get_input('map'), self.get_input('reduce'),
                            self.get_input('out'))

--- a/vistrails/packages/qgis/init.py
+++ b/vistrails/packages/qgis/init.py
@@ -47,6 +47,7 @@ import itertools
 import os
 
 class RasterLayer(Module):
+    """Renders a raster dataset onto the map."""
     _input_ports = [('file', '(basic:File)'), 
                     ('name', '(basic:String)')]
     _output_ports = [('self', '(RasterLayer)')]
@@ -65,6 +66,7 @@ class RasterLayer(Module):
         self.set_output('self', self)
 
 class VectorLayer(Module):
+    """Renders a vector based dataset onto the map."""
     _input_ports = [('file', '(basic:File)'), 
                     ('name', '(basic:String)')]
     _output_ports = [('self', '(VectorLayer)')]
@@ -83,10 +85,7 @@ class VectorLayer(Module):
         self.set_output('self', self)
 
 class QGISCell(SpreadsheetCell):
-    """
-    QGISCell is a VisTrails Module that can display QGIS inside a cell
-    
-    """
+    """QGISCell is a VisTrails Module that can display QGIS inside a cell."""
     _input_ports = [('rasterLayers', '(RasterLayer)'),
                     ('vectorLayers', '(VectorLayer)')]
 

--- a/vistrails/packages/tabledata/common.py
+++ b/vistrails/packages/tabledata/common.py
@@ -233,7 +233,7 @@ def choose_columns(nb_columns, column_names=None, names=None, indexes=None):
 class ExtractColumn(Module):
     """Gets a single column from a table, as a list.
 
-    Specifying one of 'column_name' or 'column_index' is sufficient; if you
+    Specifying one of `column_name` or `column_index` is sufficient; if you
     provide both, the module will check that the column has the expected name.
     """
     _input_ports = [

--- a/vistrails/packages/tabledata/convert/convert_dates.py
+++ b/vistrails/packages/tabledata/convert/convert_dates.py
@@ -189,19 +189,20 @@ class StringsToDates(Module):
 
     If no format is given, the dateutil.parser module will be used to guess
     what each string refers to; else, it is passed to strptime() to read each
-    date. For example: '%Y-%m-%d %H:%M:%S'.
-    The 'timezone' parameter indicates which timezone these dates are expressed
+    date. For example: `%Y-%m-%d %H:%M:%S`.
+    The `timezone` parameter indicates which timezone these dates are expressed
     in. It can be either:
-      * 'local', in which case each date is interpreted as being in whatever
+
+      - `local`, in which case each date is interpreted as being in whatever
         timezone the system is set to use;
-      * an offset in hours/minutes from UTC, for instance '-0400' for DST
+      - an offset in hours/minutes from UTC, for instance `-0400` for DST
         (eastern America time, when daylight saving is in effect). Note that in
         this case, the same offset is used for every date, without regard for
-        daylight saving (if a date falls in winter, '-0500' will not be used
+        daylight saving (if a date falls in winter, `-0500` will not be used
         instead).
-      * if pytz is available, anything else will be passed to pytz.timezone(),
-        so you would be able to use strings such as 'US/Eastern' or
-        'Europe/Amsterdam'.
+      - if pytz is available, anything else will be passed to pytz.timezone(),
+        so you would be able to use strings such as `US/Eastern` or
+        `Europe/Amsterdam`.
     """
     _input_ports = [
             ('strings', '(org.vistrails.vistrails.basic:List)'),

--- a/vistrails/packages/tabledata/operations.py
+++ b/vistrails/packages/tabledata/operations.py
@@ -151,7 +151,7 @@ class JoinTables(Table):
     match the values in the two selected columns (one from each table). If a
     row from one of the table has a value for the selected field that doesn't
     exist in the other table, that row will not appear in the result
-    (INNER JOIN semantics).
+    (*INNER JOIN* semantics).
     """
     _input_ports = [('left_table', 'Table'),
                     ('right_table', 'Table'),
@@ -382,6 +382,8 @@ class AggregatedTable(TableObject):
 
 
 class AggregateColumn(Table):
+    """Performs a *group by* operation on a table.
+    """
     _input_ports = [('table', 'Table'),
                     ('op', 'basic:String',
                      {'entry_types': "['enum']",

--- a/vistrails/packages/tabledata/read/convert.py
+++ b/vistrails/packages/tabledata/read/convert.py
@@ -166,7 +166,7 @@ class BaseListToTable(BaseConverter):
 class DictToTable(BaseDictToTable):
     """Converts a Python dictionary into a table.
 
-    This is basically the same as read.JSONObject except that it takes a live
+    This is basically the same as `read.JSONObject` except that it takes a live
     Python dictionary instead of a JSON file.
     """
     _input_ports = [('dict', '(basic:Dictionary)')]

--- a/vistrails/packages/tabledata/read/read_csv.py
+++ b/vistrails/packages/tabledata/read/read_csv.py
@@ -176,7 +176,7 @@ class CSVFile(Table):
 
     This module uses Python's csv module to read a table from a file. It is
     able to guess the actual format of the file in most cases, or you can use
-    the 'delimiter', 'header_present' and 'skip_lines' ports to force how the
+    the `delimiter`, `header_present` and `skip_lines` ports to force how the
     file will be read.
     """
     _input_ports = [

--- a/vistrails/packages/tabledata/read/read_excel.py
+++ b/vistrails/packages/tabledata/read/read_excel.py
@@ -92,8 +92,9 @@ class ExcelTable(TableObject):
 class ExcelSpreadsheet(Table):
     """Reads a table from a Microsoft Excel file.
 
-    This module uses xlrd from the python-excel.org project to read a XLS or
-    XLSX file.
+    This module uses `xlrd` from the
+    `python-excel.org <http://www.python-excel.org/>`__ project to read a XLS
+    or XLSX file.
     """
     _input_ports = [
             ('file', '(org.vistrails.vistrails.basic:File)'),

--- a/vistrails/packages/tabledata/read/read_json.py
+++ b/vistrails/packages/tabledata/read/read_json.py
@@ -55,10 +55,11 @@ class JSONTable(object):
 class JSONObject(JSONTable, DictToTable):
     """Loads a JSON file and build a table from an object.
 
-    In JSON, an object is written with {}. It is essentially an associative
+    In JSON, an object is written with `{}`. It is essentially an associative
     array. A column will contain the keys in this array.
 
-    Example:
+    Example::
+
         {
             "John": {"lastname": "Smith", "age": 25, "city": "New York"},
             "Ashley": {"lastname": "Crofts", "age": 21, "city": "Fort Worth"},
@@ -82,15 +83,16 @@ class JSONObject(JSONTable, DictToTable):
 class JSONList(JSONTable, ListToTable):
     """Loads a JSON file and build a table from a list.
 
-    In JSON, a list is written with [].
+    In JSON, a list is written with `[]`.
 
-    Example:
+    Example::
+
         [[ 4, 14, 15,  1],
          [ 9,  7,  6, 12],
          [ 5, 11, 10,  8],
          [16,  2,  3, 13]]
 
-        gives a 4x4 unnamed table.
+    gives a 4x4 unnamed table.
     """
     _input_ports = [('file', '(org.vistrails.vistrails.basic:File)')]
 

--- a/vistrails/packages/tabledata/write/write_csv.py
+++ b/vistrails/packages/tabledata/write/write_csv.py
@@ -48,7 +48,7 @@ class WriteCSV(Module):
 
     You can use the 'delimiter' and 'write_header' ports to choose the format
     you want. By default, the file will include a single-line header if the
-    table has column names, and will use semicolon separators (';').
+    table has column names, and will use semicolon separators (`;`).
     """
     _input_ports = [
             ('table', Table),


### PR DESCRIPTION
Requested by MARIN, this allows the modules to present an HTML documentation. Fixes #1206.

Currently plaintext is converted to HTML via pydoc, perhaps docutils could be used to render reStructuredText?