### PR TITLE
Add a looping indicator on modules

### DIFF
--- a/vistrails/core/theme.py
+++ b/vistrails/core/theme.py
@@ -87,6 +87,8 @@ class DefaultCoreTheme(object):
         self.CONFIGURE_WIDTH = 6
         self.CONFIGURE_HEIGHT = 10
 
+        self.LOOP_RADIUS = 5
+
         self.BREAKPOINT_FRINGE = \
             (((0.0,0.0),(-0.5,0.25),(-0.5,0.75),(0.0,1.0)),
              ((0.0,0.0),(0.5,0.25),(0.5,0.75),(0.0,1.0)))

--- a/vistrails/gui/pipeline_view.py
+++ b/vistrails/gui/pipeline_view.py
@@ -1053,11 +1053,13 @@ class QGraphicsModuleItem(QGraphicsItemInterface, QtGui.QGraphicsItem):
         self.labelFontMetric = CurrentTheme.MODULE_FONT_METRIC
         self.descFont = CurrentTheme.MODULE_DESC_FONT
         self.descFontMetric = CurrentTheme.MODULE_DESC_FONT_METRIC
+        self.loopFont = CurrentTheme.MODULE_LOOP_FONT
         self.modulePen = CurrentTheme.MODULE_PEN
         self.moduleBrush = CurrentTheme.MODULE_BRUSH
         self.labelPen = CurrentTheme.MODULE_LABEL_PEN
         self.customBrush = None
         self.statusBrush = None
+        self.loopPen = CurrentTheme.MODULE_LOOP_PEN
         self.labelRect = QtCore.QRectF()
         self.descRect = QtCore.QRectF()
         self.abstRect = QtCore.QRectF()
@@ -1292,18 +1294,23 @@ class QGraphicsModuleItem(QGraphicsItemInterface, QtGui.QGraphicsItem):
         if is_selected:
             self.modulePen = CurrentTheme.MODULE_SELECTED_PEN
             self.labelPen = CurrentTheme.MODULE_LABEL_SELECTED_PEN
+            self.loopPen = CurrentTheme.MODULE_LOOP_PEN
         elif self.is_breakpoint:
             self.modulePen = CurrentTheme.BREAKPOINT_MODULE_PEN
             self.labelPen = CurrentTheme.BREAKPOINT_MODULE_LABEL_PEN
+            self.loopPen = CurrentTheme.MODULE_LOOP_PEN
         elif self.ghosted:
             self.modulePen = CurrentTheme.GHOSTED_MODULE_PEN
             self.labelPen = CurrentTheme.GHOSTED_MODULE_LABEL_PEN
+            self.loopPen = CurrentTheme.GHOSTED_MODULE_LOOP_PEN
         # do not show as invalid in search mode
         elif self.invalid and not (self.controller and self.controller.search):
             self.modulePen = CurrentTheme.INVALID_MODULE_PEN
             self.labelPen = CurrentTheme.INVALID_MODULE_LABEL_PEN
+            self.loopPen = CurrentTheme.MODULE_LOOP_PEN
         else:
             self.labelPen = CurrentTheme.MODULE_LABEL_PEN
+            self.loopPen = CurrentTheme.MODULE_LOOP_PEN
             if self.module is not None and self.module.is_abstraction():
                 self.modulePen = CurrentTheme.ABSTRACTION_PEN
             elif self.module is not None and self.module.is_group():
@@ -1423,6 +1430,41 @@ class QGraphicsModuleItem(QGraphicsItemInterface, QtGui.QGraphicsItem):
             painter.setFont(self.descFont)
             painter.drawText(self.descRect.adjusted(-10,-10,10,10), QtCore.Qt.AlignCenter,
                              self.description)
+
+        # draw list depth
+        if self.module.list_depth > 0:
+            painter.setPen(self.loopPen)
+            radius = 5
+            pos = QtCore.QPointF(self.paddedRect.left() + 10,
+                                 self.paddedRect.bottom() - 10)
+            pos = QtCore.QPointF(self.paddedRect.right()
+                                 - CurrentTheme.CONFIGURE_WIDTH
+                                 - CurrentTheme.MODULE_PORT_MARGIN[2] * 2
+                                 - radius,
+                                 self.paddedRect.top()
+                                 + CurrentTheme.MODULE_PORT_MARGIN[1]
+                                 + radius)
+            rect = QtCore.QRectF(pos.x() - radius,
+                                 pos.y() - radius,
+                                 radius * 2,
+                                 radius * 2)
+            painter.drawArc(rect,
+                            720,  # 45 degrees
+                            4320)  # 270 degrees
+            radsq2 = radius * .707
+            painter.drawLine(QtCore.QPointF(pos.x() + radsq2,
+                                            pos.y() - radsq2),
+                             QtCore.QPointF(pos.x() + radsq2,
+                                            pos.y() - radsq2 - 3))
+            painter.drawLine(QtCore.QPointF(pos.x() + radsq2,
+                                            pos.y() - radsq2),
+                             QtCore.QPointF(pos.x() + radsq2 - 3,
+                                            pos.y() - radsq2))
+            if self.module.list_depth > 1:
+                painter.setFont(CurrentTheme.MODULE_LOOP_FONT)
+                painter.drawText(rect,
+                                 QtCore.Qt.AlignCenter,
+                                 "%d" % self.module.list_depth)
 
     def paintToPixmap(self, scale_x, scale_y):
         bounding_rect = self.paddedRect.adjusted(-6,-6,6,6)

--- a/vistrails/gui/theme.py
+++ b/vistrails/gui/theme.py
@@ -119,6 +119,8 @@ class DefaultTheme(DefaultCoreTheme):
             QtGui.QColor(*(ColorByName.get_int('black')))), 2)
         self.MODULE_LABEL_SELECTED_PEN = QtGui.QPen(QtGui.QBrush(
             QtGui.QColor(*(ColorByName.get_int('black')))), 2)
+        self.MODULE_LOOP_PEN = QtGui.QPen(QtGui.QBrush(
+            QtGui.QColor(*(ColorByName.get_int('black')))), 1)
         # Brush to draw a module shape at different states
         self.MODULE_BRUSH = QtGui.QBrush(
             QtGui.QColor(*(ColorByName.get_int('light_grey'))))
@@ -147,6 +149,8 @@ class DefaultTheme(DefaultCoreTheme):
         # Pen and brush for un-matched queried modules
         self.GHOSTED_MODULE_PEN = QtGui.QPen(QtGui.QBrush(
                 QtGui.QColor(*(ColorByName.get_int('dark_dim_grey')))), 2)
+        self.GHOSTED_MODULE_LOOP_PEN = QtGui.QPen(QtGui.QBrush(
+                QtGui.QColor(*(ColorByName.get_int('dark_dim_grey')))), 1)
         # Pen to draw module label when it is unmatched due to a query
         self.GHOSTED_MODULE_LABEL_PEN = QtGui.QPen(QtGui.QBrush(
                 QtGui.QColor(*(ColorByName.get_int('dark_dim_grey')))), 2)
@@ -320,7 +324,8 @@ class DefaultTheme(DefaultCoreTheme):
         self.MODULE_DESC_FONT_METRIC = QtGui.QFontMetrics(self.MODULE_DESC_FONT)
         self.MODULE_EDIT_FONT = QtGui.QFont(GRAPHICS_FONT, fixDPI(10))
         self.MODULE_EDIT_FONT_METRIC = QtGui.QFontMetrics(self.MODULE_EDIT_FONT)
-    
+        self.MODULE_LOOP_FONT = QtGui.QFont(GRAPHICS_FONT, fixDPI(10))
+
         # Font for version text
         self.VERSION_FONT = QtGui.QFont(GRAPHICS_FONT, fixDPI(15), QtGui.QFont.Bold)
         self.VERSION_FONT_METRIC = QtGui.QFontMetrics(self.VERSION_FONT)


### PR DESCRIPTION
This indicates clearly that a module is looping (depth>0).

![screenshot](https://cloud.githubusercontent.com/assets/426784/23684734/964502f4-036e-11e7-8329-70050eaaefda.png)

Clicking on the icon opens the looping options.