### PR TITLE
Fix usagestats requirement installation

### DIFF
--- a/vistrails/core/application.py
+++ b/vistrails/core/application.py
@@ -163,6 +163,10 @@ class VistrailsApplicationInterface(object):
 
         self.check_all_requirements()
 
+        # Setup usage reporting
+        from vistrails.core import reportusage
+        reportusage.setup_usage_report()
+
         if self.temp_configuration.check('staticRegistry'):
             self.registry = \
                 self.create_registry(self.temp_configuration.staticRegistry)
@@ -182,6 +186,12 @@ class VistrailsApplicationInterface(object):
                 'linux-ubuntu': 'python-scipy',
                 'linux-fedora': 'scipy',
                 'pip': 'scipy'})
+
+        # check usagestats
+        vistrails.core.requirements.require_python_module('usagestats', {
+                'linux-debian': 'python-usagestats',
+                'linux-ubuntu': 'python-usagestats',
+                'pip': 'usagestats'})
 
     def destroy(self):
         """ destroy() -> None

--- a/vistrails/core/reportusage.py
+++ b/vistrails/core/reportusage.py
@@ -45,7 +45,6 @@ import json
 import os
 import requests
 import tempfile
-import usagestats
 import weakref
 
 from vistrails.core import debug
@@ -53,13 +52,21 @@ from vistrails.core.system import vistrails_version, \
     vistrails_examples_directory
 
 
+usagestats = None
 usage_report = None
 
 
 def setup_usage_report():
     """Sets up the usagestats module.
     """
+    global usagestats
     global usage_report
+
+    usagestats = pyimport('usagestats', {
+        'linux-debian': ['python-usagestats'],
+        'linux-ubuntu': ['python-usagestats'],
+        'pip': ['usagestats'],
+    })
 
     certificate_file = get_ca_certificate()
 

--- a/vistrails/gui/application.py
+++ b/vistrails/gui/application.py
@@ -45,7 +45,6 @@ import os.path
 import getpass
 import sys
 import StringIO
-import usagestats
 
 from PyQt4 import QtGui, QtCore, QtNetwork
 
@@ -246,6 +245,8 @@ class VistrailsApplicationSingleton(VistrailsApplicationInterface,
         self._initialized = True
 
         # usage statistics
+        reportusage.setup_usage_report()
+        import usagestats
         if reportusage.usage_report.status is usagestats.Stats.UNSET:
             self.ask_enable_usage_report()
         # news

--- a/vistrails/run.py
+++ b/vistrails/run.py
@@ -126,9 +126,8 @@ def main():
     from vistrails.core import debug
     debug.DebugPrint.getInstance().log_to_console()
 
-    # Setup usage reporting
+    # Import this but don't set it up until application is initialized
     from vistrails.core import reportusage
-    reportusage.setup_usage_report()
 
     from vistrails.gui.requirements import require_pyqt4_api2
     require_pyqt4_api2()


### PR DESCRIPTION
VisTrails is supposed to install its requirements automatically on the first run, but currently it fails if `requests` and `usagestats` are not installed. This fixes it, but should probably be checked in more details.