### PR TITLE
sklearn traintestsplit for tabledata Tables

### DIFF
--- a/vistrails/packages/sklearn/__init__.py
+++ b/vistrails/packages/sklearn/__init__.py
@@ -34,11 +34,21 @@
 
 from __future__ import division
 
+from vistrails.core.packagemanager import get_package_manager
 from vistrails.core.requirements import require_python_module
 
 identifier = 'org.vistrails.vistrails.sklearn'
 name = 'sklearn'
 version = '0.15.2'
+
+
+def package_dependencies():
+    pm = get_package_manager()
+    tabledata_identifier = 'org.vistrails.vistrails.tabledata'
+    if pm.has_package(tabledata_identifier):
+        return [tabledata_identifier]
+    else: # pragma: no cover
+        return []
 
 
 def package_requirements():

--- a/vistrails/packages/sklearn/init.py
+++ b/vistrails/packages/sklearn/init.py
@@ -40,7 +40,8 @@ from vistrails.core.modules.vistrails_module import Module
 import numpy as np
 from sklearn.base import ClassifierMixin
 from sklearn import datasets
-from sklearn.cross_validation import train_test_split, cross_val_score
+from sklearn.model_selection import train_test_split
+from sklearn.cross_validation import cross_val_score
 from sklearn.metrics import SCORERS, roc_curve
 from sklearn.grid_search import GridSearchCV as _GridSearchCV
 from sklearn.pipeline import make_pipeline

--- a/vistrails/packages/sklearn/init.py
+++ b/vistrails/packages/sklearn/init.py
@@ -256,7 +256,7 @@ class Pipeline(Estimator):
         steps = [self.get_input(model) for model in models if model in self.inputPorts]
         pipeline = make_pipeline(*steps)
         if "training_data" in self.inputPorts:
-            training_data = np.vstack(self.get_input("training_data"))
+            training_data = self.get_input("training_data")
             training_target = self.get_input("training_target")
             pipeline.fit(training_data, training_target)
         self.set_output("model", pipeline)

--- a/vistrails/packages/sklearn/init.py
+++ b/vistrails/packages/sklearn/init.py
@@ -36,6 +36,7 @@ from __future__ import division
 
 from vistrails.core.modules.config import ModuleSettings
 from vistrails.core.modules.vistrails_module import Module
+from vistrails.core.packagemanager import get_package_manager
 
 import numpy as np
 from sklearn.base import ClassifierMixin
@@ -184,13 +185,60 @@ class TrainTestSplit(Module):
                      ("test_target", "basic:List", {'shape': 'circle'})]
 
     def compute(self):
-        X_train, X_test, y_train, y_test = \
-            train_test_split(self.get_input("data"), self.get_input("target"),
-                             test_size=try_convert(self.get_input("test_size")))
+        X_train, X_test, y_train, y_test = train_test_split(
+            self.get_input("data"),
+            self.get_input("target"),
+            test_size=try_convert(self.get_input("test_size")))
         self.set_output("training_data", X_train)
         self.set_output("training_target", y_train)
         self.set_output("test_data", X_test)
         self.set_output("test_target", y_test)
+
+
+if get_package_manager().has_package('org.vistrails.vistrails.tabledata'):
+    class TrainTestSplitTable(Module):
+        """Split data into training and testing randomly."""
+        _settings = ModuleSettings(namespace="cross-validation")
+        _input_ports = [("data", "org.vistrails.vistrails.tabledata:Table",
+                         {'shape': 'triangle'}),
+                        ("target", "basic:List", {'shape': 'circle'}),
+                        ("test_size", "basic:Float", {"defaults": [.25]})]
+        _output_ports = [("training_data",
+                          "org.vistrails.vistrails.tabledata:Table",
+                          {'shape': 'triangle'}),
+                         ("training_target", "basic:List", {'shape': 'circle'}),
+                         ("test_data",
+                          "org.vistrails.vistrails.tabledata:Table",
+                          {'shape': 'triangle'}),
+                         ("test_target", "basic:List", {'shape': 'circle'})]
+
+        def compute(self):
+            from vistrails.packages.tabledata.common import TableObject
+
+            X_table = self.get_input('data')
+            columns = X_table.columns
+            arrays = [X_table.get_column(i) for i in xrange(columns)]
+            arrays.append(self.get_input("target"))
+
+            arrays = train_test_split(
+                *arrays,
+                test_size=try_convert(self.get_input("test_size")))
+            assert len(arrays) == 2 * (columns + 1)
+
+            X_train = arrays[:-2:2]
+            X_train = TableObject(X_train, len(X_train[0]),
+                                  names=X_table.names)
+            X_test = arrays[1:-1:2]
+            X_test = TableObject(X_test, len(X_test[0]),
+                                 names=X_table.names)
+            y_train = arrays[-2]
+            y_test = arrays[-1]
+            self.set_output("training_data", X_train)
+            self.set_output("training_target", y_train)
+            self.set_output("test_data", X_test)
+            self.set_output("test_target", y_test)
+else:
+    TrainTestSplitTable = None
 
 
 class CrossValScore(Module):
@@ -417,6 +465,8 @@ _modules = [Digits, Iris, Estimator, SupervisedEstimator,
             UnsupervisedEstimator, ManifoldLearner, Predict, Transform,
             TrainTestSplit, Score, ROCCurve, CrossValScore, GridSearchCV,
             Pipeline]
+if TrainTestSplitTable is not None:
+    _modules.append(TrainTestSplitTable)
 _modules.extend(discover_supervised())
 _modules.extend(discover_clustering())
 _modules.extend(discover_unsupervised_transformers())

--- a/vistrails/packages/tabledata/read/read_csv.py
+++ b/vistrails/packages/tabledata/read/read_csv.py
@@ -128,12 +128,12 @@ class CSVTable(TableObject):
         numpy = get_numpy(False)
 
         if numeric and numpy is not None:
-            result = numpy.loadtxt(
-                    self.filename,
-                    dtype=numpy.float32,
-                    delimiter=self.delimiter,
-                    skiprows=self.skip_lines,
-                    usecols=[index])
+            with open(self.filename) as fp:
+                result = numpy.genfromtxt(fp,
+                                          dtype=numpy.float32,
+                                          delimiter=self.delimiter,
+                                          skip_header=self.skip_lines,
+                                          usecols=[index])
         else:
             with open(self.filename, 'rb') as fp:
                 for i in xrange(self.skip_lines):


### PR DESCRIPTION
Currently the old `train_test_split` (from `cross_validation`) is used, which only splits two lists (data and targets). This function is deprecated and will be removed soon.

A new `train_test_split` function has been added (under `model_selection`), which can split multiple arrays. Using this, it is possible to split a whole table in one go, which is useful for prediction from multiple features.